### PR TITLE
Added support for changing language from URL

### DIFF
--- a/src/i18n/initI18n.ts
+++ b/src/i18n/initI18n.ts
@@ -1,17 +1,12 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import detector from 'i18next-browser-languagedetector';
+import LanguageDetector from 'i18next-browser-languagedetector';
 import resourcesToBackend from 'i18next-resources-to-backend';
-
-const getLocalStorageLanguage = () => {
-    if (typeof window === 'undefined') return undefined;
-    return window?.localStorage?.getItem('i18nextLng') || undefined;
-};
 
 i18n
     // pass the i18n instance to react-i18next.
     .use(initReactI18next)
-    .use(detector)
+    .use(LanguageDetector)
     .use(
         resourcesToBackend((language: string, namespace: string) =>
             import(
@@ -22,14 +17,19 @@ i18n
 
     // init i18next
     .init({
-        lng: getLocalStorageLanguage(),
+        detection: {
+            order: ['querystring', 'localStorage'],
+            caches: ['localStorage'],
+            lookupQuerystring: 'lang',
+            lookupLocalStorage: 'i18nextLng'
+        },
         fallbackLng: 'en',
         debug: process.env.NODE_ENV === 'development' ? true : false,
         load: 'languageOnly',
         react: {
             transSupportBasicHtmlNodes: false,
         },
-        ns: ['mouse_generator'],
+        ns: ['mouse_generator']
     });
 
 export default i18n;

--- a/src/i18n/languageContext.tsx
+++ b/src/i18n/languageContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext } from 'react';
 
 import { useTranslation } from 'react-i18next';
+import { navigate } from 'gatsby';
 
 const LanguageContext = createContext(
     {} as {
@@ -18,8 +19,8 @@ export const LanguageProvider = ({ children }) => {
                 language: i18n.language,
                 setLanguage: (language: string) => {
                     i18n.changeLanguage(language);
-                    window.localStorage.setItem('i18nextLng', language);
-                },
+                    navigate(`?lang=${language}`, { replace: true })
+                }
             }}
         >
             {children}


### PR DESCRIPTION
This change adds support for navigating to pages with predefined localization.
For example, a link like this navigates directly to the Italian version of Item Card Studio:
https://mausritter.com/item-card-studio/?lang=it

Language modifier is only added to the  URL address after user changes the localization.
If no language modifier is specified, local storage is used instead for storing current localization.