### PR TITLE
Czech translation

### DIFF
--- a/src/components/generators/adventureSite/adventureSiteGeneratorTypes.ts
+++ b/src/components/generators/adventureSite/adventureSiteGeneratorTypes.ts
@@ -8,8 +8,8 @@ export type RoomTypeData = {
 
 export type AdventureSiteGeneratorData = {
     siteName: {
-        partA: string[];
-        partB: string[];
+        modifier: string[];
+        location: string[];
     };
     summary: {
         format: string;

--- a/src/components/generators/adventureSite/useAdventureSite.ts
+++ b/src/components/generators/adventureSite/useAdventureSite.ts
@@ -1,8 +1,7 @@
 import { useState } from 'react';
-import { sum, times, drop, max, compact } from 'lodash/fp';
 import { nanoid } from 'nanoid';
 
-import { pick, rollDice, weightedPick } from '../generatorUtils';
+import { pick, pickWithContext, rollDice, weightedPick } from '../generatorUtils';
 
 import { ROOM_LAYOUTS } from './adventureSiteConstants';
 import {
@@ -13,19 +12,21 @@ import {
 const createAdventureSiteData = (
     generatorData: AdventureSiteGeneratorData
 ): AdventureSite => {
-    const name = `${pick(generatorData.siteName.partA)} ${pick(
-        generatorData.siteName.partB
-    )}`;
+    const context = new Map();
+
+    const location = pickWithContext(generatorData.siteName.location, 'location', context);
+    const modifier = pickWithContext(generatorData.siteName.modifier, 'modifier', context);
+    const name = `${modifier} ${location}`;
 
     const summary = {
-        construction: pick(generatorData.summary.construction),
-        ruinAction: pick(generatorData.summary.ruinAction),
-        ruin: pick(generatorData.summary.ruin),
-        inhabitant: pick(generatorData.summary.inhabitant),
-        inhabitantAction: pick(generatorData.summary.inhabitantAction),
-        inhabitantGoal: pick(generatorData.summary.inhabitantGoal),
-        secretHidden: pick(generatorData.summary.secretHidden),
-        secret: pick(generatorData.summary.secret),
+        construction: pickWithContext(generatorData.summary.construction, 'construction', context),
+        ruinAction: pickWithContext(generatorData.summary.ruinAction, 'ruinAction', context),
+        ruin: pickWithContext(generatorData.summary.ruin, 'ruin', context),
+        inhabitant: pickWithContext(generatorData.summary.inhabitant, 'inhabitant', context),
+        inhabitantAction: pickWithContext(generatorData.summary.inhabitantAction, 'inhabitantAction', context),
+        inhabitantGoal: pickWithContext(generatorData.summary.inhabitantGoal, 'inhabitantGoal', context),
+        secretHidden: pickWithContext(generatorData.summary.secretHidden, 'secretHidden', context),
+        secret: pickWithContext(generatorData.summary.secret, 'secret', context)
     };
 
     const rooms = pick(ROOM_LAYOUTS).map((position) => {

--- a/src/components/generators/generatorUtils.ts
+++ b/src/components/generators/generatorUtils.ts
@@ -2,10 +2,12 @@ import { isEmpty } from 'lodash';
 import { sum, times, get, split, toPairs, isString, isObject, isArray, includes } from 'lodash/fp';
 
 export const resolveWithContext = (input: any, key: string, context: Map<string, string[]>) => {
+    // If input value is simple string, return it's value directly since it doesn't use context 
     if (isString(input)) {
         return input;
     }
 
+    // Ensure that input value is string or object 
     if (!isObject(input)) {
         console.error("Expected string or object as input!", input)
         return '[error]';
@@ -16,17 +18,17 @@ export const resolveWithContext = (input: any, key: string, context: Map<string,
     // Try to lookup matching translation
     for (const [property, value] of toPairs(input)) {
 
-        const parts = split('_', property);
-
         // If property name is exactly the key without any conditions eg: "familyName"
         // use it as fallback translation, when no other matching property is found
-        if (parts.length == 1 && property == key) {
+        if (property == key) {
             if (result == null) {
                 result = value;
             }
 
             continue;
         }
+
+        const parts = split('_', property);
 
         // Property name must begin with key or it's not a translation
         // eg: "familyName_"
@@ -35,7 +37,7 @@ export const resolveWithContext = (input: any, key: string, context: Map<string,
         }
 
         // Go trough declared conditions for this translation:
-        // eg: "familyName_firstName:male"
+        // eg: "familyName_firstName=male"
         for (let i = 1; i < parts.length; i++) {
             // Get current condition from parts
             const conditionValue = parts[i];
@@ -60,6 +62,7 @@ export const resolveWithContext = (input: any, key: string, context: Map<string,
 
     }
 
+    // Display error, if no translation was matched
     if (result == null) {
         console.error("Unable to resolve value with given context!", input, key, context);
         return '[error]';
@@ -67,6 +70,7 @@ export const resolveWithContext = (input: any, key: string, context: Map<string,
 
     const contextValue = get('context', input);
 
+    // Store custom context under resolution key, if resolved input specifies any
     if (!isEmpty(contextValue)) {
         context.set(key, isArray(contextValue) ? contextValue : [contextValue]);
     }
@@ -74,9 +78,8 @@ export const resolveWithContext = (input: any, key: string, context: Map<string,
     return result;
 }
 
-export const pickWithContext = <T>(array: T[], key: string, context: Map<string, string[]>) => {
-    return resolveWithContext(pick(array), key, context);
-}
+export const pickWithContext = <T>(array: T[], key: string, context: Map<string, string[]>) =>
+    resolveWithContext(pick(array), key, context);
 
 export const pick = <T>(array: T[]) =>
     array[Math.floor(Math.random() * array.length)];

--- a/src/components/generators/generatorUtils.ts
+++ b/src/components/generators/generatorUtils.ts
@@ -1,4 +1,82 @@
-import { sum, times } from 'lodash/fp';
+import { isEmpty } from 'lodash';
+import { sum, times, get, split, toPairs, isString, isObject, isArray, includes } from 'lodash/fp';
+
+export const resolveWithContext = (input: any, key: string, context: Map<string, string[]>) => {
+    if (isString(input)) {
+        return input;
+    }
+
+    if (!isObject(input)) {
+        console.error("Expected string or object as input!", input)
+        return '[error]';
+    }
+
+    let result = null;
+
+    // Try to lookup matching translation
+    for (const [property, value] of toPairs(input)) {
+
+        const parts = split('_', property);
+
+        // If property name is exactly the key without any conditions eg: "familyName"
+        // use it as fallback translation, when no other matching property is found
+        if (parts.length == 1 && property == key) {
+            if (result == null) {
+                result = value;
+            }
+
+            continue;
+        }
+
+        // Property name must begin with key or it's not a translation
+        // eg: "familyName_"
+        if (parts[0] != key) {
+            continue;
+        }
+
+        // Go trough declared conditions for this translation:
+        // eg: "familyName_firstName:male"
+        for (let i = 1; i < parts.length; i++) {
+            // Get current condition from parts
+            const conditionValue = parts[i];
+
+            // Parse condition with equal condition to extract key and value
+            const conditionParts = split('=', conditionValue);
+
+            // Condition must have exactly one equal operator or it's invalid
+            if (conditionParts.length != 2) {
+                break;
+            }
+
+            const [lookupKey, lookupValue] = conditionParts;
+
+            // Check if translation condition is matched
+            if (!includes(lookupValue, context.get(lookupKey))) {
+                break;
+            }
+
+            result = value;
+        }
+
+    }
+
+    if (result == null) {
+        console.error("Unable to resolve value with given context!", input, key, context);
+        return '[error]';
+    }
+
+    const contextValue = get('context', input);
+
+    if (!isEmpty(contextValue)) {
+        context.set(key, isArray(contextValue) ? contextValue : [contextValue]);
+    }
+
+    return result;
+}
+
+export const pickWithContext = <T>(array: T[], key: string, context: Map<string, string[]>) => {
+    return resolveWithContext(pick(array), key, context);
+}
 
 export const pick = <T>(array: T[]) =>
     array[Math.floor(Math.random() * array.length)];

--- a/src/components/navigation/language/LanguageSelect.tsx
+++ b/src/components/navigation/language/LanguageSelect.tsx
@@ -8,7 +8,7 @@ import { Helmet } from 'react-helmet';
 const LANGUAGE_OPTIONS = [
     { value: 'en', label: '🇬🇧 English' },
     { value: 'it', label: '🇮🇹 Italiano' },
-	{ value: 'cs', label: '🇨🇿 Čeština' }
+    { value: 'cs', label: '🇨🇿 Čeština' }
 ];
 
 const Container = styled.div`

--- a/src/components/navigation/language/LanguageSelect.tsx
+++ b/src/components/navigation/language/LanguageSelect.tsx
@@ -8,6 +8,7 @@ import { Helmet } from 'react-helmet';
 const LANGUAGE_OPTIONS = [
     { value: 'en', label: '🇬🇧 English' },
     { value: 'it', label: '🇮🇹 Italiano' },
+	{ value: 'cs', label: '🇨🇿 Čeština' }
 ];
 
 const Container = styled.div`

--- a/src/locales/cs/adventure_site_generator.json
+++ b/src/locales/cs/adventure_site_generator.json
@@ -1,248 +1,584 @@
 {
-    "title": "Delving into...",
-    "pageTitle": "Adventure Site Generator",
-    "ui": {
-        "rollButton": "Roll again"
-    },
-    "labels": {
-        "creature": "Creature",
-        "treasure": "Treasure"
-    },
-    "other": {
-        "credits": "Icons from <a href=\"https://game-icons.net/\">game-icons.net</a>. Chest by <a href=\"http://lorcblog.blogspot.com/\">Lorc</a>. Spider by <a href=\"https://twitter.com/unstoppableCarl\">Carl Olsen</a>."
-    },
-    "data": {
-        "siteName": {
-            "partA": [
-                "Black",
-                "White",
-                "Green",
-                "Blue",
-                "Red",
-                "Onyx",
-                "Emerald",
-                "Overgrown",
-                "Hidden",
-                "Charred",
-                "Burned",
-                "Lost",
-                "Broken",
-                "Golden",
-                "Bloody",
-                "Widow’s",
-                "Vine",
-                "Bone",
-                "Dry",
-                "Sodden"
-            ],
-            "partB": [
-                "Stump",
-                "Tree",
-                "Oak",
-                "Pine",
-                "Spire",
-                "Tower",
-                "Mot",
-                "Castle",
-                "Fort",
-                "Keep",
-                "Palace",
-                "Grave",
-                "Tomb",
-                "Vault",
-                "Crypt",
-                "Boneyard",
-                "Den",
-                "Sett",
-                "Lair",
-                "Burrow",
-                "Hole",
-                "Cave",
-                "Hollow",
-                "Shelter",
-                "Temple",
-                "Sanctuary",
-                "Shrine"
-            ]
-        },
-        "summary": {
-            "format": ", {{- construction}} {{- ruinAction}} <b>{{- ruin}}</b>. <b>{{- inhabitant}}</b> {{- inhabitantAction}} <b>{{- inhabitantGoal}}</b>. {{- secretHidden}} <b>{{- secret}}</b>",
-            "construction": [
-                "an <b>ancient bat cult temple</b>",
-                "a <b>long-abandoned watchtower</b>",
-                "a <b>noblemouse’s country manor</b>",
-                "a <b>hidden winter storehouse</b>",
-                "a <b>burial site of ancient mice</b>",
-                "a <b>warren dug by rabbits or foxes</b>",
-                "a <b>human house or other building</b>",
-                "a series of <b>sewer or drainage pipes</b>",
-                "a series of <b>claustrophobic ant-dug tunnels</b>",
-                "a <b>massive tree, carved out by mice</b>",
-                "a <b>wizard’s tower</b>",
-                "a <b>settlement’s grain mill</b>",
-                "a <b>rat king’s nest</b>",
-                "the <b>skeleton of a great beast</b>",
-                "a <b>witch’s academy</b>",
-                "a <b>gatehouse to the faerie realm</b>",
-                "a <b>deep mine</b>",
-                "a <b>bandit’s hideout</b>",
-                "a <b>natural cave</b>",
-                "a <b>mouse settlement</b>"
-            ],
-            "ruinAction": [
-                "ruined by",
-                "in ruins due to",
-                "desecrated by",
-                "left crumbling by",
-                "almost destroyed by",
-                "in a decrepit state due to"
-            ],
-            "ruin": [
-                "flooding",
-                "a magical mishap",
-                "age and rot",
-                "human destruction",
-                "mold",
-                "shifting between realms",
-                "attacks from a great beast",
-                "a disastrous storm",
-                "haunting spirits",
-                "mysterious abandonment",
-                "internal warfare",
-                "disease"
-            ],
-            "inhabitant": [
-                "Mice, driven mad or desperate",
-                "Mice, magically altered",
-                "Rat bandits",
-                "Creatures from a distant land",
-                "The original residents, strangely twisted",
-                "Ghostly spirits",
-                "A faerie advance guard",
-                "A foul-tempered snake",
-                "An infestation of insects",
-                "A cat lord and their servants"
-            ],
-            "inhabitantAction": [
-                "search for",
-                "protect",
-                "guard",
-                "hunt for"
-            ],
-            "inhabitantGoal": [
-                "a safe place to live or hide",
-                "a cache of fine food",
-                "a lost family or friend",
-                "ancient, valuable artworks",
-                "the last scraps in a picked-over ruin",
-                "rare alchemical mushrooms",
-                "a strange and powerful spell",
-                "a vast horde of pips"
-            ],
-            "secretHidden": [
-                "Deep within",
-                "Hidden away",
-                "Unknown to all",
-                "Beneath"
-            ],
-            "secret": [
-                "is a <b>monolith humming with arcane energy</b>",
-                "is a <b>preserved precursor beast</b>",
-                "are <b>signs of human experimentation</b>",
-                "is the <b>forgotten grave of an ancient queen</b>",
-                "is a <b>path into the veins of the earth</b>",
-                "is a <b>portal to the faerie realm</b>"
-            ]
-        },
-        "roomTypes": [
-            {
-                "typeName": "Empty",
-                "weight": 2,
-                "creatureChance": 3,
-                "treasureChance": 1,
-                "descriptions": [
-                    "Abandoned insect nest",
-                    "Cluster of mushrooms",
-                    "Collapsed wall or ceiling",
-                    "Dried bug shells on the walls",
-                    "Furniture made of repurposed trash",
-                    "Huge drawing of bat face on wall",
-                    "Mess of tables and chairs",
-                    "Newspaper clipping wallpaper",
-                    "Overgrown with moss",
-                    "Painted mural, now faded",
-                    "Platforms hanging over rapidly flowing water",
-                    "Roots bursting out of walls/floor/ceiling",
-                    "Rotting pile of acorns",
-                    "Scattering of animal teeth",
-                    "Shiny candy-wrapper banners ",
-                    "Snake skull doorway",
-                    "Steady drip of water from ceiling",
-                    "Stern statue of an ancient mouse",
-                    "Uneven and deeply cracked floor",
-                    "White quartz altar"
-                ]
-            },
-            {
-                "typeName": "Obstacle",
-                "weight": 1,
-                "creatureChance": 2,
-                "treasureChance": 1,
-                "descriptions": [
-                    "Locked door. Key can be found in another room. Knocking the door down takes time and makes noise.",
-                    "Steep climb. Without special equipment, mice risk exhaustion or falling.",
-                    "Room with an exit in the centre of the roof, 6\" away from any wall.",
-                    "Device that creates an high-pitched scream. Each Turn spent here or in adjacent rooms gives Frightened Condition.",
-                    "Caved-in section of tunnel, leaving a gap too small to crawl through.",
-                    "Tunnel completely filled with water.",
-                    "Wide, deep puddle of mud blocking the way. Gives an Exhausted Condition per 6\" traveled.",
-                    "Long, smooth, upwards sloping metal or plastic tube."
-                ]
-            },
-            {
-                "typeName": "Trap",
-                "weight": 1,
-                "creatureChance": 1,
-                "treasureChance": 2,
-                "descriptions": [
-                    "Large stone door, chiseled loose from frame. Device behind the door tips it forward when handle is turned.",
-                    "Long hallway flooded with water, electrified by large battery in an alcove.",
-                    "Dark room filled with noxious, explosive gas. Distinct smell of rotten eggs. d20 damage if ignited.",
-                    "Thin thread stretched across deadly fall. Safe if traveling slowly, one at a time.",
-                    "Pit blocking the way. A snake is asleep at the bottom.",
-                    "Door with three handles in the shape of mushrooms, one safe, the others poison. Poison handles deal d12 magical damage.",
-                    "Circle of enchanted mushrooms, with a young mouse inside. Those within try desperately to get others to enter.",
-                    "Floor is covered in sticky glue. Requires a STR save to break a foot loose."
-                ]
-            },
-            {
-                "typeName": "Puzzle",
-                "weight": 1,
-                "creatureChance": 1,
-                "treasureChance": 5,
-                "descriptions": [
-                    "Room with a floor made of an electrified copper plate. A piece of valuable treasure sits in the centre.",
-                    "Three feeding bottles with different-colored liquid inside. Each is inert individually but powerful/dangerous when mixed.",
-                    "A crystal, a magic sword embedded inside. The crystal is very hard, but will dissolve in stomach acid.",
-                    "Treasure is at the bottom of deep well. ",
-                    "Large smooth steel bowl, upside down. Treasure taped to the inside ceiling of the bowl.",
-                    "Baited mousetrap. The lever is wired to a stone in the wall and will collapse the corridor if triggered"
-                ]
-            },
-            {
-                "typeName": "Lair",
-                "weight": 1,
-                "creatureChance": 5,
-                "treasureChance": 4,
-                "descriptions": [
-                    "Temporary encampment",
-                    "Recently taken from another creature",
-                    "Built by mice to hold the creature",
-                    "Protecting young",
-                    "Permanent home, newly settled",
-                    "Permanent home, comfortably appointed"
-                ]
-            }
-        ]
-    }
+	"title": "Jdeme prozkoumat...",
+	"pageTitle": "Generátor Dobrodružných Míst",
+	"ui": {
+		"rollButton": "Hoď znovu"
+	},
+	"labels": {
+		"creature": "Stvoření",
+		"treasure": "Poklad"
+	},
+	"other": {
+		"credits": "Ikony z <a href=\"https://game-icons.net/\">game-icons.net</a>. Truhlu vytvořil <a href=\"http://lorcblog.blogspot.com/\">Lorc</a>. Pavouka vytvořil <a href=\"https://twitter.com/unstoppableCarl\">Carl Olsen</a>. Překlad do českého jazyka <a href=\"https://github.com/Filipsi\">Filipsi</a>."
+	},
+	"data": {
+		"siteName": {
+			"modifier": [
+				{
+					"modifier_location=male": "Černý",
+					"modifier_location=female": "Černá",
+					"modifier_location=it": "Černé"
+				},
+				{
+					"modifier_location=male": "Bílý",
+					"modifier_location=female": "Bílá",
+					"modifier_location=it": "Bílé"
+				},
+				{
+					"modifier_location=male": "Zelený",
+					"modifier_location=female": "Zelená",
+					"modifier_location=it": "Zelené"
+				},
+				{
+					"modifier_location=male": "Modrý",
+					"modifier_location=female": "Modrá",
+					"modifier_location=it": "Modré"
+				},
+				{
+					"modifier_location=male": "Červený",
+					"modifier_location=female": "Červená",
+					"modifier_location=it": "Červené"
+				},
+				{
+					"modifier_location=male": "Onyxový",
+					"modifier_location=female": "Onyxová",
+					"modifier_location=it": "Onyxové"
+				},
+				{
+					"modifier_location=male": "Smaragdový",
+					"modifier_location=female": "Smaragdová",
+					"modifier_location=it": "Smaragdové"
+				},
+				{
+					"modifier_location=male": "Zarostlý",
+					"modifier_location=female": "Zarostlá",
+					"modifier_location=it": "Zarostlé"
+				},
+				{
+					"modifier_location=male": "Skrytý",
+					"modifier_location=female": "Skrytá",
+					"modifier_location=it": "Skryté"
+				},
+				{
+					"modifier_location=male": "Zuhelnatělý",
+					"modifier_location=female": "Zuhelnatělá",
+					"modifier_location=it": "Zuhelnatělé"
+				},
+				{
+					"modifier_location=male": "Spálený",
+					"modifier_location=female": "Spálená",
+					"modifier_location=it": "Spálené"
+				},
+				{
+					"modifier_location=male": "Ztracený",
+					"modifier_location=female": "Ztracená",
+					"modifier_location=it": "Ztracené"
+				},
+				{
+					"modifier_location=male": "Starý",
+					"modifier_location=female": "Stará",
+					"modifier_location=it": "Staré"
+				},
+				{
+					"modifier_location=male": "Zlatý",
+					"modifier_location=female": "Zlatá",
+					"modifier_location=it": "Zlaté"
+				},
+				{
+					"modifier_location=male": "Krvavý",
+					"modifier_location=female": "Krvavá",
+					"modifier_location=it": "Krvavé"
+				},
+				{
+					"modifier_location=male": "Vdoví",
+					"modifier_location=female": "Vdoví",
+					"modifier_location=it": "Vdoví"
+				},
+				{
+					"modifier_location=male": "Zarostlý",
+					"modifier_location=female": "Zarostlá",
+					"modifier_location=it": "Zarostlé"
+				},
+				{
+					"modifier_location=male": "Kostěný",
+					"modifier_location=female": "Kostěná",
+					"modifier_location=it": "Kostěné"
+				},
+				{
+					"modifier_location=male": "Suchý",
+					"modifier_location=female": "Suchá",
+					"modifier_location=it": "Suché"
+				},
+				{
+					"modifier_location=male": "Promočený",
+					"modifier_location=female": "Promočená",
+					"modifier_location=it": "Promočené"
+				}
+			],
+			"location": [
+				{
+					"location": "Pařez",
+					"context": "male"
+				},
+				{
+					"location": "Strom",
+					"context": "male"
+				},
+				{
+					"location": "Dub",
+					"context": "male"
+				},
+				{
+					"location": "Borovice",
+					"context": "female"
+				},
+				{
+					"location": "Věžička",
+					"context": "female"
+				},
+				{
+					"location": "Věž",
+					"context": "female"
+				},
+				{
+					"location": "Věž",
+					"context": "female"
+				},
+				{
+					"location": "Příkop",
+					"context": "male"
+				},
+				{
+					"location": "Hrad",
+					"context": "male"
+				},
+				{
+					"location": "Pevnost",
+					"context": "female"
+				},
+				{
+					"location": "Palác",
+					"context": "male"
+				},
+				{
+					"location": "Hrob",
+					"context": "male"
+				},
+				{
+					"location": "Hrobka",
+					"context": "female"
+				},
+				{
+					"location": "Krypta",
+					"context": "female"
+				},
+				{
+					"location": "Pohřebiště",
+					"context": "it"
+				},
+				{
+					"location": "Doupě",
+					"context": "it"
+				},
+				{
+					"location": "Nora",
+					"context": "female"
+				},
+				{
+					"location": "Brloh",
+					"context": "male"
+				},
+				{
+					"location": "Tunel",
+					"context": "male"
+				},
+				{
+					"location": "Díra",
+					"context": "female"
+				},
+				{
+					"location": "Jeskyně",
+					"context": "female"
+				},
+				{
+					"location": "Dutina",
+					"context": "female"
+				},
+				{
+					"location": "Přístřešek",
+					"context": "male"
+				},
+				{
+					"location": "Chrám",
+					"context": "male"
+				},
+				{
+					"location": "Útočiště",
+					"context": "it"
+				},
+				{
+					"location": "Svatyně",
+					"context": "female"
+				}
+			]
+		},
+		"summary": {
+			"format": " - {{- construction}} {{- ruinAction}} {{- ruin}}. {{- inhabitant}} {{- inhabitantAction}} {{- inhabitantGoal}}. {{- secretHidden}} {{- secret}}.",
+			"construction": [
+				{
+					"construction": "<b>starověký chrám</b> netopýřího kultu",
+					"context": "male"
+				},
+				{
+					"construction": "dlouho opuštěná <b>strážní věž</b>",
+					"context": "female"
+				},
+				{
+					"construction": "šlechticův <b>venkovský statek</b>",
+					"context": "male"
+				},
+				{
+					"construction": "tajný <b>sklad zásob na zimu</b>",
+					"context": "male"
+				},
+				{
+					"construction": "starověké <b>myší pohřebiště</b>",
+					"context": "it"
+				},
+				{
+					"construction": "<b>nora</b> vykopaná králíky nebo liškami",
+					"context": "female"
+				},
+				{
+					"construction": "<b>lidský dům</b> nebo jiná budova",
+					"context": "female"
+				},
+				{
+					"construction": "série kanalizačních nebo drenážních <b>trubek</b>",
+					"context": "female"
+				},
+				{
+					"construction": "série klaustrofobních <b>tunelů</b> vykopaných mravenci",
+					"context": "female"
+				},
+				{
+					"construction": "<b>mohutný strom</b> vydlabaný myšmi",
+					"context": "male"
+				},
+				{
+					"construction": "<b>kouzelnická věž</b>",
+					"context": "female"
+				},
+				{
+					"construction": "<b>mlýn na obilí</b> nedaleké osady",
+					"context": "male"
+				},
+				{
+					"construction": "<b>hnízdo krysího krále</b>",
+					"context": "it"
+				},
+				{
+					"construction": "<b>kostra</b> velkého zvířete",
+					"context": "female"
+				},
+				{
+					"construction": "čarodějnická <b>akademie</b>",
+					"context": "female"
+				},
+				{
+					"construction": "<b>brána</b> do říše víl",
+					"context": "female"
+				},
+				{
+					"construction": "hluboký <b>důl</b>",
+					"context": "male"
+				},
+				{
+					"construction": "<b>úkryt</b> banditů",
+					"context": "male"
+				},
+				{
+					"construction": "přírodní <b>jeskyně</b>",
+					"context": "female"
+				},
+				{
+					"construction": "myší <b>osada</b>",
+					"context": "female"
+				}
+			],
+			"ruinAction": [
+				{
+					"ruinAction_construction=male": "zničen",
+					"ruinAction_construction=female": "zničena",
+					"ruinAction_construction=it": "zničeno",
+					"context": "damage"
+				},
+				{
+					"ruinAction_construction=male": "zdevastován",
+					"ruinAction_construction=female": "zdevastovana",
+					"ruinAction_construction=it": "zdevastované",
+					"context": "damage"
+				},
+				{
+					"ruinAction": "v troskách",
+					"context": "because"
+				},
+				{
+					"ruinAction_construction=male": "znesvěcen",
+					"ruinAction_construction=female": "znesvěcena",
+					"ruinAction_construction=it": "znesvěcené",
+					"context": "damage"
+				},
+				{
+					"ruinAction_construction=male": "nechán na pospas živlům",
+					"ruinAction_construction=female": "nechaná na pospas živlům",
+					"ruinAction_construction=it": "necháno na pospas živlům",
+					"context": "because"
+				},
+				{
+					"ruinAction_construction=male": "jenž málem zanikl",
+					"ruinAction_construction=female": "jenž málem zanikla",
+					"ruinAction_construction=it": "jenž málem zaniklo",
+					"context": "because"
+				},
+				{
+					"ruinAction_construction=male": "skoro zničen",
+					"ruinAction_construction=female": "skoro zničena",
+					"ruinAction_construction=it": "skoro zničeno"
+				},
+				{
+					"ruinAction_construction=male": "poškozen",
+					"ruinAction_construction=female": "poškozena",
+					"ruinAction_construction=it": "poškozeno",
+					"context": "damage"
+				}
+			],
+			"ruin": [
+				{
+					"ruin": "<b>záplavami</b>",
+					"ruin_ruinAction=because": "kvůli <b>záplavám</b>"
+				},
+				{
+					"ruin": "<b>magickým neštěstím</b>",
+					"ruin_ruinAction=because": "díky <b>magickému neštěstí</b>"
+				},
+				{
+					"ruin": "<b>stářím</b> a <b>hnilobou</b>",
+					"ruin_ruinAction=because": "kvůli <b>stáří</b> a <b>hnilobě</b>"
+				},
+				{
+					"ruin": "<b>lidskou činností</b>",
+					"ruin_ruinAction=because": "kvůli <b>lidské činnosti</b>"
+				},
+				{
+					"ruin": "<b>plísní</b>",
+					"ruin_ruinAction=because": "kvůli <b>plísni</b>"
+				},
+				{
+					"ruin": "<b>přesunem mezi sférami</b>",
+					"ruin_ruinAction=because": "kvůli <b>přesunu mezi sférami</b>"
+				},
+				{
+					"ruin": "<b>útokem</b> velké šelmy",
+					"ruin_ruinAction=because": "kvůli <b>útoku</b> velké šelmy"
+				},
+				{
+					"ruin": "ničivou <b>bouří</b>",
+					"ruin_ruinAction=because": "kvůli ničivé <b>bouři</b>"
+				},
+				{
+					"ruin": "<b>strašením duchů</b>",
+					"ruin_ruinAction=because": "kvůli <b>strašidelným duchům</b>",
+					"ruin_ruinAction=damage": "<b>strašidelnými duchy</b>"
+				},
+				{
+					"ruin": "záhadným <b>odchodem obyvatel</b>",
+					"ruin_ruinAction=because": "kvůli záhadnému <b>odchodu obyvatel</b>",
+					"ruin_ruinAction=damage": "při záhadném <b>odchodu obyvatel</b>"
+				},
+				{
+					"ruin": "<b>spory mezi obyvateli</b>",
+					"ruin_ruinAction=because": "kvůli <b>sporům mezi obyvateli</b>",
+					"ruin_ruinAction=damage": "při <b>sporech mezi obyvateli</b>"
+				},
+				{
+					"ruin": "<b>chorobou</b>",
+					"ruin_ruinAction=because": "kvůli <b>šířící se chorobě</b>",
+					"ruin_ruinAction=damage": "<b>nemocnými obyvateli</b>"
+				}
+			],
+			"inhabitant": [
+				{
+					"inhabitant": "Šílené nebo zoufalé myši",
+					"context": "many"
+				},
+				{
+					"inhabitant": "Magicky změněné myši",
+					"context": "many"
+				},
+				{
+					"inhabitant": "Krysí bandité",
+					"context": "many"
+				},
+				{
+					"inhabitant": "Bytosti ze vzdálené země",
+					"context": "many"
+				},
+				{
+					"inhabitant": "Podivně změnění původní obyvatelé",
+					"context": "many"
+				},
+				{
+					"inhabitant": "Přízrační duchové",
+					"context": "many"
+				},
+				{
+					"inhabitant": "Předsunutá vílí hlídka",
+					"context": "many"
+				},
+				{
+					"inhabitant": "Had ve špatné náladě",
+					"context": "one"
+				},
+				{
+					"inhabitant": "Hmyzí zamoření",
+					"context": "one"
+				},
+				{
+					"inhabitant": "Kočičí pán a jeho služebníci",
+					"context": "many"
+				}
+			],
+			"inhabitantAction": [
+				{
+					"inhabitantAction_inhabitant=one": "tu hledá",
+					"inhabitantAction": "tu hledají"
+				},
+				{
+					"inhabitantAction": "tu chrání"
+				},
+				{
+					"inhabitantAction_inhabitant=one": "tu hlídá",
+					"inhabitantAction": "tu hlídají"
+				},
+				{
+					"inhabitantAction": "se tu snaží najít"
+				}
+			],
+			"inhabitantGoal": [
+				"<b>bezpečné místo</b> k životu nebo úkrytu",
+				"<b>skrýš</b> dobrého jídla",
+				"<b>ztracenou</b> rodinu nebo přítele",
+				"cenná starověká <b>umělecká díla</b>",
+				"poslední <b>cennosti</b> v prohrabané ruině",
+				"vzácné <b>alchymistické houby</b>",
+				"zvláštní a mocné <b>kouzlo</b>",
+				"obrovskou hordu <b>ďobek</b>"
+			],
+			"secretHidden": [
+				"Hluboko uvnitř je",
+				"V zapomenutém koutu je",
+				"Nikdo si už nepamatuje, kde je",
+				"Pod zemí je"
+			],
+			"secret": [
+				"<b>monolit</b> šumící tajemnou energií",
+				"zachovalá <b>prapůvodní šelma</b>",
+				"možné najít známky <b>lidských</b> experimentů",
+				"<b>hrob</b> starověké královny",
+				"cesta do <b>žil země</b>",
+				"<b>portál</b> do říše víl"
+			]
+		},
+		"roomTypes": [
+			{
+				"typeName": "Prázdno",
+				"weight": 2,
+				"creatureChance": 3,
+				"treasureChance": 1,
+				"descriptions": [
+					"Opuštěné hnízdo hmyzu",
+					"Shluk hub",
+					"Zhroucená stěna nebo strop",
+					"Suché skořápky brouků na stěnách",
+					"Nábytek vyrobený z hrampádí",
+					"Obrovská kresba netopýří tváře na zdi",
+					"Rozházené stoly a židle",
+					"Tapeta z novinových výstřižků",
+					"Zarostlé mechem",
+					"Nástěnná malba, nyní vybledlá",
+					"Plošiny visící nad rychle tekoucí vodou",
+					"Kořeny rostoucí ze zdí/podlahy/stropu",
+					"Hnijící hromada žaludů",
+					"Rozházené zvířecí zuby",
+					"Lesklé obaly od bonbónů",
+					"Dveře z hadí lebky",
+					"Voda neustále kape ze stropu",
+					"Nevlídná socha starověké myši",
+					"Nerovná a hluboce popraskaná podlaha",
+					"Bílý křemenný oltář"
+				]
+			},
+			{
+				"typeName": "Překážka",
+				"weight": 1,
+				"creatureChance": 2,
+				"treasureChance": 1,
+				"descriptions": [
+					"Zamčené dveře. Klíč najdete v jiné místnosti. Vykopnutí dveří bude nějakou dobru trvat a možná to někdo uslyší.",
+					"Strmé stoupání. Bez speciálního vybavení hrozí myším vyčerpání nebo pád.",
+					"Pokoj s východem uprostřed stropu, 15 cm od jakékoli stěny.",
+					"Zařízení, ze kterého je slyšet nepříjemně vysoký tón. Každý tah strávený zde nebo v sousedních místnostech způsobí stav Vystrašení.",
+					"Zřícená část tunelu s příliš malým průlezem.",
+					"Tunel zcela zaplněný vodou.",
+					"Široká louže bahna blokující cestu. Po ujití 15 cm způsobí stav Vyčerpání ",
+					"Dlouhá trubka z kovu nebo platu stočená nahoru."
+				]
+			},
+			{
+				"typeName": "Past",
+				"weight": 1,
+				"creatureChance": 1,
+				"treasureChance": 2,
+				"descriptions": [
+					"Velké kamenné dveře povolené z rámu. Zařízení za dveřmi je při otočení klikou nakloní dopředu.",
+					"Dlouhá chodba zaplavená vodou, elektrifikovaná velkou baterií skrytou ve výklenku.",
+					"Temná místnost plná výbušného plynu. Výrazná vůně zkažených vajec. Způsobí k20 poškození při vznícení.",
+					"Tenká nit natažená přes smrtící propast. Bezpečné, pokud cestujete pomalu, jeden po druhém.",
+					"Jáma blokující cestu. Na dně spí had.",
+					"Dveře se třemi klikami ve tvaru hřibů, jedna je bezpečná, ostatní jsou jedovaté. Jedovatá rukojet způsobí k12 magického poškození.",
+					"Kruh kouzelných hub s mladou myškou uvnitř. Ti uvnitř kruhu se zoufale snaží přimět ostatní, aby vstoupili.",
+					"Podlaha je pokryta lepidlem. K uvolnění nohy je potřeba provést záchranu na sílu."
+				]
+			},
+			{
+				"typeName": "Hádanka",
+				"weight": 1,
+				"creatureChance": 1,
+				"treasureChance": 5,
+				"descriptions": [
+					"Místnost s podlahou z elektrifikované měděné desky. Uprostřed je kousek cenného pokladu.",
+					"Tři kojenecké lahve s různobarevnou tekutinou uvnitř. Samotné jsou inertní, ale smíchaný koncentrát je nebezpečný.",
+					"Kouzelný meč zapuštěný v průhledném krystalu. Je sice velmi tvrdý, ale rozpustí se v žaludeční kyselině.",
+					"Poklad na dně hluboké studny.",
+					"Velká hladká ocelová mísa, dnem vzhůru. Poklad nalepený na vnitřním stropě mísy.",
+					"Past na myši s návnadou. Mechanizmus je spojen s kameny ve zdi a při aktivaci zhroutí chodbou."
+				]
+			},
+			{
+				"typeName": "Doupě",
+				"weight": 1,
+				"creatureChance": 5,
+				"treasureChance": 4,
+				"descriptions": [
+					"Dočasné tábořiště",
+					"Nedávno patřilo jinému tvorovi",
+					"Postaveno myšmi, k uvěznění tvora",
+					"Střeží mladé",
+					"Trvalý domov, nově zabydlený",
+					"Trvalý domov, komfortně zařízený"
+				]
+			}
+		]
+	}
 }

--- a/src/locales/cs/adventure_site_generator.json
+++ b/src/locales/cs/adventure_site_generator.json
@@ -1,584 +1,584 @@
 {
-	"title": "Jdeme prozkoumat...",
-	"pageTitle": "Generátor Dobrodružných Míst",
-	"ui": {
-		"rollButton": "Hoď znovu"
-	},
-	"labels": {
-		"creature": "Stvoření",
-		"treasure": "Poklad"
-	},
-	"other": {
-		"credits": "Ikony z <a href=\"https://game-icons.net/\">game-icons.net</a>. Truhlu vytvořil <a href=\"http://lorcblog.blogspot.com/\">Lorc</a>. Pavouka vytvořil <a href=\"https://twitter.com/unstoppableCarl\">Carl Olsen</a>. Překlad do českého jazyka <a href=\"https://github.com/Filipsi\">Filipsi</a>."
-	},
-	"data": {
-		"siteName": {
-			"modifier": [
-				{
-					"modifier_location=male": "Černý",
-					"modifier_location=female": "Černá",
-					"modifier_location=it": "Černé"
-				},
-				{
-					"modifier_location=male": "Bílý",
-					"modifier_location=female": "Bílá",
-					"modifier_location=it": "Bílé"
-				},
-				{
-					"modifier_location=male": "Zelený",
-					"modifier_location=female": "Zelená",
-					"modifier_location=it": "Zelené"
-				},
-				{
-					"modifier_location=male": "Modrý",
-					"modifier_location=female": "Modrá",
-					"modifier_location=it": "Modré"
-				},
-				{
-					"modifier_location=male": "Červený",
-					"modifier_location=female": "Červená",
-					"modifier_location=it": "Červené"
-				},
-				{
-					"modifier_location=male": "Onyxový",
-					"modifier_location=female": "Onyxová",
-					"modifier_location=it": "Onyxové"
-				},
-				{
-					"modifier_location=male": "Smaragdový",
-					"modifier_location=female": "Smaragdová",
-					"modifier_location=it": "Smaragdové"
-				},
-				{
-					"modifier_location=male": "Zarostlý",
-					"modifier_location=female": "Zarostlá",
-					"modifier_location=it": "Zarostlé"
-				},
-				{
-					"modifier_location=male": "Skrytý",
-					"modifier_location=female": "Skrytá",
-					"modifier_location=it": "Skryté"
-				},
-				{
-					"modifier_location=male": "Zuhelnatělý",
-					"modifier_location=female": "Zuhelnatělá",
-					"modifier_location=it": "Zuhelnatělé"
-				},
-				{
-					"modifier_location=male": "Spálený",
-					"modifier_location=female": "Spálená",
-					"modifier_location=it": "Spálené"
-				},
-				{
-					"modifier_location=male": "Ztracený",
-					"modifier_location=female": "Ztracená",
-					"modifier_location=it": "Ztracené"
-				},
-				{
-					"modifier_location=male": "Starý",
-					"modifier_location=female": "Stará",
-					"modifier_location=it": "Staré"
-				},
-				{
-					"modifier_location=male": "Zlatý",
-					"modifier_location=female": "Zlatá",
-					"modifier_location=it": "Zlaté"
-				},
-				{
-					"modifier_location=male": "Krvavý",
-					"modifier_location=female": "Krvavá",
-					"modifier_location=it": "Krvavé"
-				},
-				{
-					"modifier_location=male": "Vdoví",
-					"modifier_location=female": "Vdoví",
-					"modifier_location=it": "Vdoví"
-				},
-				{
-					"modifier_location=male": "Zarostlý",
-					"modifier_location=female": "Zarostlá",
-					"modifier_location=it": "Zarostlé"
-				},
-				{
-					"modifier_location=male": "Kostěný",
-					"modifier_location=female": "Kostěná",
-					"modifier_location=it": "Kostěné"
-				},
-				{
-					"modifier_location=male": "Suchý",
-					"modifier_location=female": "Suchá",
-					"modifier_location=it": "Suché"
-				},
-				{
-					"modifier_location=male": "Promočený",
-					"modifier_location=female": "Promočená",
-					"modifier_location=it": "Promočené"
-				}
-			],
-			"location": [
-				{
-					"location": "Pařez",
-					"context": "male"
-				},
-				{
-					"location": "Strom",
-					"context": "male"
-				},
-				{
-					"location": "Dub",
-					"context": "male"
-				},
-				{
-					"location": "Borovice",
-					"context": "female"
-				},
-				{
-					"location": "Věžička",
-					"context": "female"
-				},
-				{
-					"location": "Věž",
-					"context": "female"
-				},
-				{
-					"location": "Věž",
-					"context": "female"
-				},
-				{
-					"location": "Příkop",
-					"context": "male"
-				},
-				{
-					"location": "Hrad",
-					"context": "male"
-				},
-				{
-					"location": "Pevnost",
-					"context": "female"
-				},
-				{
-					"location": "Palác",
-					"context": "male"
-				},
-				{
-					"location": "Hrob",
-					"context": "male"
-				},
-				{
-					"location": "Hrobka",
-					"context": "female"
-				},
-				{
-					"location": "Krypta",
-					"context": "female"
-				},
-				{
-					"location": "Pohřebiště",
-					"context": "it"
-				},
-				{
-					"location": "Doupě",
-					"context": "it"
-				},
-				{
-					"location": "Nora",
-					"context": "female"
-				},
-				{
-					"location": "Brloh",
-					"context": "male"
-				},
-				{
-					"location": "Tunel",
-					"context": "male"
-				},
-				{
-					"location": "Díra",
-					"context": "female"
-				},
-				{
-					"location": "Jeskyně",
-					"context": "female"
-				},
-				{
-					"location": "Dutina",
-					"context": "female"
-				},
-				{
-					"location": "Přístřešek",
-					"context": "male"
-				},
-				{
-					"location": "Chrám",
-					"context": "male"
-				},
-				{
-					"location": "Útočiště",
-					"context": "it"
-				},
-				{
-					"location": "Svatyně",
-					"context": "female"
-				}
-			]
-		},
-		"summary": {
-			"format": " - {{- construction}} {{- ruinAction}} {{- ruin}}. {{- inhabitant}} {{- inhabitantAction}} {{- inhabitantGoal}}. {{- secretHidden}} {{- secret}}.",
-			"construction": [
-				{
-					"construction": "<b>starověký chrám</b> netopýřího kultu",
-					"context": "male"
-				},
-				{
-					"construction": "dlouho opuštěná <b>strážní věž</b>",
-					"context": "female"
-				},
-				{
-					"construction": "šlechticův <b>venkovský statek</b>",
-					"context": "male"
-				},
-				{
-					"construction": "tajný <b>sklad zásob na zimu</b>",
-					"context": "male"
-				},
-				{
-					"construction": "starověké <b>myší pohřebiště</b>",
-					"context": "it"
-				},
-				{
-					"construction": "<b>nora</b> vykopaná králíky nebo liškami",
-					"context": "female"
-				},
-				{
-					"construction": "<b>lidský dům</b> nebo jiná budova",
-					"context": "female"
-				},
-				{
-					"construction": "série kanalizačních nebo drenážních <b>trubek</b>",
-					"context": "female"
-				},
-				{
-					"construction": "série klaustrofobních <b>tunelů</b> vykopaných mravenci",
-					"context": "female"
-				},
-				{
-					"construction": "<b>mohutný strom</b> vydlabaný myšmi",
-					"context": "male"
-				},
-				{
-					"construction": "<b>kouzelnická věž</b>",
-					"context": "female"
-				},
-				{
-					"construction": "<b>mlýn na obilí</b> nedaleké osady",
-					"context": "male"
-				},
-				{
-					"construction": "<b>hnízdo krysího krále</b>",
-					"context": "it"
-				},
-				{
-					"construction": "<b>kostra</b> velkého zvířete",
-					"context": "female"
-				},
-				{
-					"construction": "čarodějnická <b>akademie</b>",
-					"context": "female"
-				},
-				{
-					"construction": "<b>brána</b> do říše víl",
-					"context": "female"
-				},
-				{
-					"construction": "hluboký <b>důl</b>",
-					"context": "male"
-				},
-				{
-					"construction": "<b>úkryt</b> banditů",
-					"context": "male"
-				},
-				{
-					"construction": "přírodní <b>jeskyně</b>",
-					"context": "female"
-				},
-				{
-					"construction": "myší <b>osada</b>",
-					"context": "female"
-				}
-			],
-			"ruinAction": [
-				{
-					"ruinAction_construction=male": "zničen",
-					"ruinAction_construction=female": "zničena",
-					"ruinAction_construction=it": "zničeno",
-					"context": "damage"
-				},
-				{
-					"ruinAction_construction=male": "zdevastován",
-					"ruinAction_construction=female": "zdevastovana",
-					"ruinAction_construction=it": "zdevastované",
-					"context": "damage"
-				},
-				{
-					"ruinAction": "v troskách",
-					"context": "because"
-				},
-				{
-					"ruinAction_construction=male": "znesvěcen",
-					"ruinAction_construction=female": "znesvěcena",
-					"ruinAction_construction=it": "znesvěcené",
-					"context": "damage"
-				},
-				{
-					"ruinAction_construction=male": "nechán na pospas živlům",
-					"ruinAction_construction=female": "nechaná na pospas živlům",
-					"ruinAction_construction=it": "necháno na pospas živlům",
-					"context": "because"
-				},
-				{
-					"ruinAction_construction=male": "jenž málem zanikl",
-					"ruinAction_construction=female": "jenž málem zanikla",
-					"ruinAction_construction=it": "jenž málem zaniklo",
-					"context": "because"
-				},
-				{
-					"ruinAction_construction=male": "skoro zničen",
-					"ruinAction_construction=female": "skoro zničena",
-					"ruinAction_construction=it": "skoro zničeno"
-				},
-				{
-					"ruinAction_construction=male": "poškozen",
-					"ruinAction_construction=female": "poškozena",
-					"ruinAction_construction=it": "poškozeno",
-					"context": "damage"
-				}
-			],
-			"ruin": [
-				{
-					"ruin": "<b>záplavami</b>",
-					"ruin_ruinAction=because": "kvůli <b>záplavám</b>"
-				},
-				{
-					"ruin": "<b>magickým neštěstím</b>",
-					"ruin_ruinAction=because": "díky <b>magickému neštěstí</b>"
-				},
-				{
-					"ruin": "<b>stářím</b> a <b>hnilobou</b>",
-					"ruin_ruinAction=because": "kvůli <b>stáří</b> a <b>hnilobě</b>"
-				},
-				{
-					"ruin": "<b>lidskou činností</b>",
-					"ruin_ruinAction=because": "kvůli <b>lidské činnosti</b>"
-				},
-				{
-					"ruin": "<b>plísní</b>",
-					"ruin_ruinAction=because": "kvůli <b>plísni</b>"
-				},
-				{
-					"ruin": "<b>přesunem mezi sférami</b>",
-					"ruin_ruinAction=because": "kvůli <b>přesunu mezi sférami</b>"
-				},
-				{
-					"ruin": "<b>útokem</b> velké šelmy",
-					"ruin_ruinAction=because": "kvůli <b>útoku</b> velké šelmy"
-				},
-				{
-					"ruin": "ničivou <b>bouří</b>",
-					"ruin_ruinAction=because": "kvůli ničivé <b>bouři</b>"
-				},
-				{
-					"ruin": "<b>strašením duchů</b>",
-					"ruin_ruinAction=because": "kvůli <b>strašidelným duchům</b>",
-					"ruin_ruinAction=damage": "<b>strašidelnými duchy</b>"
-				},
-				{
-					"ruin": "záhadným <b>odchodem obyvatel</b>",
-					"ruin_ruinAction=because": "kvůli záhadnému <b>odchodu obyvatel</b>",
-					"ruin_ruinAction=damage": "při záhadném <b>odchodu obyvatel</b>"
-				},
-				{
-					"ruin": "<b>spory mezi obyvateli</b>",
-					"ruin_ruinAction=because": "kvůli <b>sporům mezi obyvateli</b>",
-					"ruin_ruinAction=damage": "při <b>sporech mezi obyvateli</b>"
-				},
-				{
-					"ruin": "<b>chorobou</b>",
-					"ruin_ruinAction=because": "kvůli <b>šířící se chorobě</b>",
-					"ruin_ruinAction=damage": "<b>nemocnými obyvateli</b>"
-				}
-			],
-			"inhabitant": [
-				{
-					"inhabitant": "Šílené nebo zoufalé myši",
-					"context": "many"
-				},
-				{
-					"inhabitant": "Magicky změněné myši",
-					"context": "many"
-				},
-				{
-					"inhabitant": "Krysí bandité",
-					"context": "many"
-				},
-				{
-					"inhabitant": "Bytosti ze vzdálené země",
-					"context": "many"
-				},
-				{
-					"inhabitant": "Podivně změnění původní obyvatelé",
-					"context": "many"
-				},
-				{
-					"inhabitant": "Přízrační duchové",
-					"context": "many"
-				},
-				{
-					"inhabitant": "Předsunutá vílí hlídka",
-					"context": "many"
-				},
-				{
-					"inhabitant": "Had ve špatné náladě",
-					"context": "one"
-				},
-				{
-					"inhabitant": "Hmyzí zamoření",
-					"context": "one"
-				},
-				{
-					"inhabitant": "Kočičí pán a jeho služebníci",
-					"context": "many"
-				}
-			],
-			"inhabitantAction": [
-				{
-					"inhabitantAction_inhabitant=one": "tu hledá",
-					"inhabitantAction": "tu hledají"
-				},
-				{
-					"inhabitantAction": "tu chrání"
-				},
-				{
-					"inhabitantAction_inhabitant=one": "tu hlídá",
-					"inhabitantAction": "tu hlídají"
-				},
-				{
-					"inhabitantAction": "se tu snaží najít"
-				}
-			],
-			"inhabitantGoal": [
-				"<b>bezpečné místo</b> k životu nebo úkrytu",
-				"<b>skrýš</b> dobrého jídla",
-				"<b>ztracenou</b> rodinu nebo přítele",
-				"cenná starověká <b>umělecká díla</b>",
-				"poslední <b>cennosti</b> v prohrabané ruině",
-				"vzácné <b>alchymistické houby</b>",
-				"zvláštní a mocné <b>kouzlo</b>",
-				"obrovskou hordu <b>ďobek</b>"
-			],
-			"secretHidden": [
-				"Hluboko uvnitř je",
-				"V zapomenutém koutu je",
-				"Nikdo si už nepamatuje, kde je",
-				"Pod zemí je"
-			],
-			"secret": [
-				"<b>monolit</b> šumící tajemnou energií",
-				"zachovalá <b>prapůvodní šelma</b>",
-				"možné najít známky <b>lidských</b> experimentů",
-				"<b>hrob</b> starověké královny",
-				"cesta do <b>žil země</b>",
-				"<b>portál</b> do říše víl"
-			]
-		},
-		"roomTypes": [
-			{
-				"typeName": "Prázdno",
-				"weight": 2,
-				"creatureChance": 3,
-				"treasureChance": 1,
-				"descriptions": [
-					"Opuštěné hnízdo hmyzu",
-					"Shluk hub",
-					"Zhroucená stěna nebo strop",
-					"Suché skořápky brouků na stěnách",
-					"Nábytek vyrobený z hrampádí",
-					"Obrovská kresba netopýří tváře na zdi",
-					"Rozházené stoly a židle",
-					"Tapeta z novinových výstřižků",
-					"Zarostlé mechem",
-					"Nástěnná malba, nyní vybledlá",
-					"Plošiny visící nad rychle tekoucí vodou",
-					"Kořeny rostoucí ze zdí/podlahy/stropu",
-					"Hnijící hromada žaludů",
-					"Rozházené zvířecí zuby",
-					"Lesklé obaly od bonbónů",
-					"Dveře z hadí lebky",
-					"Voda neustále kape ze stropu",
-					"Nevlídná socha starověké myši",
-					"Nerovná a hluboce popraskaná podlaha",
-					"Bílý křemenný oltář"
-				]
-			},
-			{
-				"typeName": "Překážka",
-				"weight": 1,
-				"creatureChance": 2,
-				"treasureChance": 1,
-				"descriptions": [
-					"Zamčené dveře. Klíč najdete v jiné místnosti. Vykopnutí dveří bude nějakou dobru trvat a možná to někdo uslyší.",
-					"Strmé stoupání. Bez speciálního vybavení hrozí myším vyčerpání nebo pád.",
-					"Pokoj s východem uprostřed stropu, 15 cm od jakékoli stěny.",
-					"Zařízení, ze kterého je slyšet nepříjemně vysoký tón. Každý tah strávený zde nebo v sousedních místnostech způsobí stav Vystrašení.",
-					"Zřícená část tunelu s příliš malým průlezem.",
-					"Tunel zcela zaplněný vodou.",
-					"Široká louže bahna blokující cestu. Po ujití 15 cm způsobí stav Vyčerpání ",
-					"Dlouhá trubka z kovu nebo platu stočená nahoru."
-				]
-			},
-			{
-				"typeName": "Past",
-				"weight": 1,
-				"creatureChance": 1,
-				"treasureChance": 2,
-				"descriptions": [
-					"Velké kamenné dveře povolené z rámu. Zařízení za dveřmi je při otočení klikou nakloní dopředu.",
-					"Dlouhá chodba zaplavená vodou, elektrifikovaná velkou baterií skrytou ve výklenku.",
-					"Temná místnost plná výbušného plynu. Výrazná vůně zkažených vajec. Způsobí k20 poškození při vznícení.",
-					"Tenká nit natažená přes smrtící propast. Bezpečné, pokud cestujete pomalu, jeden po druhém.",
-					"Jáma blokující cestu. Na dně spí had.",
-					"Dveře se třemi klikami ve tvaru hřibů, jedna je bezpečná, ostatní jsou jedovaté. Jedovatá rukojet způsobí k12 magického poškození.",
-					"Kruh kouzelných hub s mladou myškou uvnitř. Ti uvnitř kruhu se zoufale snaží přimět ostatní, aby vstoupili.",
-					"Podlaha je pokryta lepidlem. K uvolnění nohy je potřeba provést záchranu na sílu."
-				]
-			},
-			{
-				"typeName": "Hádanka",
-				"weight": 1,
-				"creatureChance": 1,
-				"treasureChance": 5,
-				"descriptions": [
-					"Místnost s podlahou z elektrifikované měděné desky. Uprostřed je kousek cenného pokladu.",
-					"Tři kojenecké lahve s různobarevnou tekutinou uvnitř. Samotné jsou inertní, ale smíchaný koncentrát je nebezpečný.",
-					"Kouzelný meč zapuštěný v průhledném krystalu. Je sice velmi tvrdý, ale rozpustí se v žaludeční kyselině.",
-					"Poklad na dně hluboké studny.",
-					"Velká hladká ocelová mísa, dnem vzhůru. Poklad nalepený na vnitřním stropě mísy.",
-					"Past na myši s návnadou. Mechanizmus je spojen s kameny ve zdi a při aktivaci zhroutí chodbou."
-				]
-			},
-			{
-				"typeName": "Doupě",
-				"weight": 1,
-				"creatureChance": 5,
-				"treasureChance": 4,
-				"descriptions": [
-					"Dočasné tábořiště",
-					"Nedávno patřilo jinému tvorovi",
-					"Postaveno myšmi, k uvěznění tvora",
-					"Střeží mladé",
-					"Trvalý domov, nově zabydlený",
-					"Trvalý domov, komfortně zařízený"
-				]
-			}
-		]
-	}
+    "title": "Jdeme prozkoumat...",
+    "pageTitle": "Generátor Dobrodružných Míst",
+    "ui": {
+        "rollButton": "Hoď znovu"
+    },
+    "labels": {
+        "creature": "Stvoření",
+        "treasure": "Poklad"
+    },
+    "other": {
+        "credits": "Ikony z <a href=\"https://game-icons.net/\">game-icons.net</a>. Truhlu vytvořil <a href=\"http://lorcblog.blogspot.com/\">Lorc</a>. Pavouka vytvořil <a href=\"https://twitter.com/unstoppableCarl\">Carl Olsen</a>. Překlad do českého jazyka <a href=\"https://github.com/Filipsi\">Filipsi</a>."
+    },
+    "data": {
+        "siteName": {
+            "modifier": [
+                {
+                    "modifier_location=male": "Černý",
+                    "modifier_location=female": "Černá",
+                    "modifier_location=it": "Černé"
+                },
+                {
+                    "modifier_location=male": "Bílý",
+                    "modifier_location=female": "Bílá",
+                    "modifier_location=it": "Bílé"
+                },
+                {
+                    "modifier_location=male": "Zelený",
+                    "modifier_location=female": "Zelená",
+                    "modifier_location=it": "Zelené"
+                },
+                {
+                    "modifier_location=male": "Modrý",
+                    "modifier_location=female": "Modrá",
+                    "modifier_location=it": "Modré"
+                },
+                {
+                    "modifier_location=male": "Červený",
+                    "modifier_location=female": "Červená",
+                    "modifier_location=it": "Červené"
+                },
+                {
+                    "modifier_location=male": "Onyxový",
+                    "modifier_location=female": "Onyxová",
+                    "modifier_location=it": "Onyxové"
+                },
+                {
+                    "modifier_location=male": "Smaragdový",
+                    "modifier_location=female": "Smaragdová",
+                    "modifier_location=it": "Smaragdové"
+                },
+                {
+                    "modifier_location=male": "Zarostlý",
+                    "modifier_location=female": "Zarostlá",
+                    "modifier_location=it": "Zarostlé"
+                },
+                {
+                    "modifier_location=male": "Skrytý",
+                    "modifier_location=female": "Skrytá",
+                    "modifier_location=it": "Skryté"
+                },
+                {
+                    "modifier_location=male": "Zuhelnatělý",
+                    "modifier_location=female": "Zuhelnatělá",
+                    "modifier_location=it": "Zuhelnatělé"
+                },
+                {
+                    "modifier_location=male": "Spálený",
+                    "modifier_location=female": "Spálená",
+                    "modifier_location=it": "Spálené"
+                },
+                {
+                    "modifier_location=male": "Ztracený",
+                    "modifier_location=female": "Ztracená",
+                    "modifier_location=it": "Ztracené"
+                },
+                {
+                    "modifier_location=male": "Starý",
+                    "modifier_location=female": "Stará",
+                    "modifier_location=it": "Staré"
+                },
+                {
+                    "modifier_location=male": "Zlatý",
+                    "modifier_location=female": "Zlatá",
+                    "modifier_location=it": "Zlaté"
+                },
+                {
+                    "modifier_location=male": "Krvavý",
+                    "modifier_location=female": "Krvavá",
+                    "modifier_location=it": "Krvavé"
+                },
+                {
+                    "modifier_location=male": "Vdoví",
+                    "modifier_location=female": "Vdoví",
+                    "modifier_location=it": "Vdoví"
+                },
+                {
+                    "modifier_location=male": "Zarostlý",
+                    "modifier_location=female": "Zarostlá",
+                    "modifier_location=it": "Zarostlé"
+                },
+                {
+                    "modifier_location=male": "Kostěný",
+                    "modifier_location=female": "Kostěná",
+                    "modifier_location=it": "Kostěné"
+                },
+                {
+                    "modifier_location=male": "Suchý",
+                    "modifier_location=female": "Suchá",
+                    "modifier_location=it": "Suché"
+                },
+                {
+                    "modifier_location=male": "Promočený",
+                    "modifier_location=female": "Promočená",
+                    "modifier_location=it": "Promočené"
+                }
+            ],
+            "location": [
+                {
+                    "location": "Pařez",
+                    "context": "male"
+                },
+                {
+                    "location": "Strom",
+                    "context": "male"
+                },
+                {
+                    "location": "Dub",
+                    "context": "male"
+                },
+                {
+                    "location": "Borovice",
+                    "context": "female"
+                },
+                {
+                    "location": "Věžička",
+                    "context": "female"
+                },
+                {
+                    "location": "Věž",
+                    "context": "female"
+                },
+                {
+                    "location": "Věž",
+                    "context": "female"
+                },
+                {
+                    "location": "Příkop",
+                    "context": "male"
+                },
+                {
+                    "location": "Hrad",
+                    "context": "male"
+                },
+                {
+                    "location": "Pevnost",
+                    "context": "female"
+                },
+                {
+                    "location": "Palác",
+                    "context": "male"
+                },
+                {
+                    "location": "Hrob",
+                    "context": "male"
+                },
+                {
+                    "location": "Hrobka",
+                    "context": "female"
+                },
+                {
+                    "location": "Krypta",
+                    "context": "female"
+                },
+                {
+                    "location": "Pohřebiště",
+                    "context": "it"
+                },
+                {
+                    "location": "Doupě",
+                    "context": "it"
+                },
+                {
+                    "location": "Nora",
+                    "context": "female"
+                },
+                {
+                    "location": "Brloh",
+                    "context": "male"
+                },
+                {
+                    "location": "Tunel",
+                    "context": "male"
+                },
+                {
+                    "location": "Díra",
+                    "context": "female"
+                },
+                {
+                    "location": "Jeskyně",
+                    "context": "female"
+                },
+                {
+                    "location": "Dutina",
+                    "context": "female"
+                },
+                {
+                    "location": "Přístřešek",
+                    "context": "male"
+                },
+                {
+                    "location": "Chrám",
+                    "context": "male"
+                },
+                {
+                    "location": "Útočiště",
+                    "context": "it"
+                },
+                {
+                    "location": "Svatyně",
+                    "context": "female"
+                }
+            ]
+        },
+        "summary": {
+            "format": " - {{- construction}} {{- ruinAction}} {{- ruin}}. {{- inhabitant}} {{- inhabitantAction}} {{- inhabitantGoal}}. {{- secretHidden}} {{- secret}}.",
+            "construction": [
+                {
+                    "construction": "<b>starověký chrám</b> netopýřího kultu",
+                    "context": "male"
+                },
+                {
+                    "construction": "dlouho opuštěná <b>strážní věž</b>",
+                    "context": "female"
+                },
+                {
+                    "construction": "šlechticův <b>venkovský statek</b>",
+                    "context": "male"
+                },
+                {
+                    "construction": "tajný <b>sklad zásob na zimu</b>",
+                    "context": "male"
+                },
+                {
+                    "construction": "starověké <b>myší pohřebiště</b>",
+                    "context": "it"
+                },
+                {
+                    "construction": "<b>nora</b> vykopaná králíky nebo liškami",
+                    "context": "female"
+                },
+                {
+                    "construction": "<b>lidský dům</b> nebo jiná budova",
+                    "context": "female"
+                },
+                {
+                    "construction": "série kanalizačních nebo drenážních <b>trubek</b>",
+                    "context": "female"
+                },
+                {
+                    "construction": "série klaustrofobních <b>tunelů</b> vykopaných mravenci",
+                    "context": "female"
+                },
+                {
+                    "construction": "<b>mohutný strom</b> vydlabaný myšmi",
+                    "context": "male"
+                },
+                {
+                    "construction": "<b>kouzelnická věž</b>",
+                    "context": "female"
+                },
+                {
+                    "construction": "<b>mlýn na obilí</b> nedaleké osady",
+                    "context": "male"
+                },
+                {
+                    "construction": "<b>hnízdo krysího krále</b>",
+                    "context": "it"
+                },
+                {
+                    "construction": "<b>kostra</b> velkého zvířete",
+                    "context": "female"
+                },
+                {
+                    "construction": "čarodějnická <b>akademie</b>",
+                    "context": "female"
+                },
+                {
+                    "construction": "<b>brána</b> do říše víl",
+                    "context": "female"
+                },
+                {
+                    "construction": "hluboký <b>důl</b>",
+                    "context": "male"
+                },
+                {
+                    "construction": "<b>úkryt</b> banditů",
+                    "context": "male"
+                },
+                {
+                    "construction": "přírodní <b>jeskyně</b>",
+                    "context": "female"
+                },
+                {
+                    "construction": "myší <b>osada</b>",
+                    "context": "female"
+                }
+            ],
+            "ruinAction": [
+                {
+                    "ruinAction_construction=male": "zničen",
+                    "ruinAction_construction=female": "zničena",
+                    "ruinAction_construction=it": "zničeno",
+                    "context": "damage"
+                },
+                {
+                    "ruinAction_construction=male": "zdevastován",
+                    "ruinAction_construction=female": "zdevastovaná",
+                    "ruinAction_construction=it": "zdevastované",
+                    "context": "damage"
+                },
+                {
+                    "ruinAction": "v troskách",
+                    "context": "because"
+                },
+                {
+                    "ruinAction_construction=male": "znesvěcen",
+                    "ruinAction_construction=female": "znesvěcena",
+                    "ruinAction_construction=it": "znesvěcené",
+                    "context": "damage"
+                },
+                {
+                    "ruinAction_construction=male": "nechaný na pospas živlům",
+                    "ruinAction_construction=female": "nechaná na pospas živlům",
+                    "ruinAction_construction=it": "necháno na pospas živlům",
+                    "context": "because"
+                },
+                {
+                    "ruinAction_construction=male": "jenž málem zanikl",
+                    "ruinAction_construction=female": "jenž málem zanikla",
+                    "ruinAction_construction=it": "jenž málem zaniklo",
+                    "context": "because"
+                },
+                {
+                    "ruinAction_construction=male": "skoro zničen",
+                    "ruinAction_construction=female": "skoro zničená",
+                    "ruinAction_construction=it": "skoro zničeno"
+                },
+                {
+                    "ruinAction_construction=male": "poškozen",
+                    "ruinAction_construction=female": "poškozena",
+                    "ruinAction_construction=it": "poškozeno",
+                    "context": "damage"
+                }
+            ],
+            "ruin": [
+                {
+                    "ruin": "<b>záplavami</b>",
+                    "ruin_ruinAction=because": "kvůli <b>záplavám</b>"
+                },
+                {
+                    "ruin": "<b>magickým neštěstím</b>",
+                    "ruin_ruinAction=because": "díky <b>magickému neštěstí</b>"
+                },
+                {
+                    "ruin": "<b>stářím</b> a <b>hnilobou</b>",
+                    "ruin_ruinAction=because": "kvůli <b>stáří</b> a <b>hnilobě</b>"
+                },
+                {
+                    "ruin": "<b>lidskou činností</b>",
+                    "ruin_ruinAction=because": "kvůli <b>lidské činnosti</b>"
+                },
+                {
+                    "ruin": "<b>plísní</b>",
+                    "ruin_ruinAction=because": "kvůli <b>plísni</b>"
+                },
+                {
+                    "ruin": "<b>přesunem mezi sférami</b>",
+                    "ruin_ruinAction=because": "kvůli <b>přesunu mezi sférami</b>"
+                },
+                {
+                    "ruin": "<b>útokem</b> velké šelmy",
+                    "ruin_ruinAction=because": "kvůli <b>útoku</b> velké šelmy"
+                },
+                {
+                    "ruin": "ničivou <b>bouří</b>",
+                    "ruin_ruinAction=because": "kvůli ničivé <b>bouři</b>"
+                },
+                {
+                    "ruin": "<b>strašením duchů</b>",
+                    "ruin_ruinAction=because": "kvůli <b>strašidelným duchům</b>",
+                    "ruin_ruinAction=damage": "<b>strašidelnými duchy</b>"
+                },
+                {
+                    "ruin": "záhadným <b>odchodem obyvatel</b>",
+                    "ruin_ruinAction=because": "kvůli záhadnému <b>odchodu obyvatel</b>",
+                    "ruin_ruinAction=damage": "při záhadném <b>odchodu obyvatel</b>"
+                },
+                {
+                    "ruin": "<b>spory mezi obyvateli</b>",
+                    "ruin_ruinAction=because": "kvůli <b>sporům mezi obyvateli</b>",
+                    "ruin_ruinAction=damage": "při <b>sporech mezi obyvateli</b>"
+                },
+                {
+                    "ruin": "<b>chorobou</b>",
+                    "ruin_ruinAction=because": "kvůli <b>šířící se chorobě</b>",
+                    "ruin_ruinAction=damage": "<b>nemocnými obyvateli</b>"
+                }
+            ],
+            "inhabitant": [
+                {
+                    "inhabitant": "Šílené nebo zoufalé myši",
+                    "context": "many"
+                },
+                {
+                    "inhabitant": "Magicky změněné myši",
+                    "context": "many"
+                },
+                {
+                    "inhabitant": "Krysí bandité",
+                    "context": "many"
+                },
+                {
+                    "inhabitant": "Bytosti ze vzdálené země",
+                    "context": "many"
+                },
+                {
+                    "inhabitant": "Podivně změnění původní obyvatelé",
+                    "context": "many"
+                },
+                {
+                    "inhabitant": "Přízrační duchové",
+                    "context": "many"
+                },
+                {
+                    "inhabitant": "Předsunutá vílí hlídka",
+                    "context": "many"
+                },
+                {
+                    "inhabitant": "Had ve špatné náladě",
+                    "context": "one"
+                },
+                {
+                    "inhabitant": "Hmyzí zamoření",
+                    "context": "one"
+                },
+                {
+                    "inhabitant": "Kočičí pán a jeho služebníci",
+                    "context": "many"
+                }
+            ],
+            "inhabitantAction": [
+                {
+                    "inhabitantAction_inhabitant=one": "tu hledá",
+                    "inhabitantAction": "tu hledají"
+                },
+                {
+                    "inhabitantAction": "tu chrání"
+                },
+                {
+                    "inhabitantAction_inhabitant=one": "tu hlídá",
+                    "inhabitantAction": "tu hlídají"
+                },
+                {
+                    "inhabitantAction": "se tu snaží najít"
+                }
+            ],
+            "inhabitantGoal": [
+                "<b>bezpečné místo</b> k životu nebo úkrytu",
+                "<b>skrýš</b> dobrého jídla",
+                "<b>ztracenou</b> rodinu nebo přítele",
+                "cenná starověká <b>umělecká díla</b>",
+                "poslední <b>cennosti</b> v prohrabané ruině",
+                "vzácné <b>alchymistické houby</b>",
+                "zvláštní a mocné <b>kouzlo</b>",
+                "obrovskou hordu <b>ďobek</b>"
+            ],
+            "secretHidden": [
+                "Hluboko uvnitř je",
+                "V zapomenutém koutu je",
+                "Nikdo si už nepamatuje, kde je",
+                "Pod zemí je"
+            ],
+            "secret": [
+                "<b>monolit</b> šumící tajemnou energií",
+                "zachovalá <b>prapůvodní šelma</b>",
+                "možné najít známky <b>lidských</b> experimentů",
+                "<b>hrob</b> starověké královny",
+                "cesta do <b>žil země</b>",
+                "<b>portál</b> do říše víl"
+            ]
+        },
+        "roomTypes": [
+            {
+                "typeName": "Prázdno",
+                "weight": 2,
+                "creatureChance": 3,
+                "treasureChance": 1,
+                "descriptions": [
+                    "Opuštěné hnízdo hmyzu",
+                    "Shluk hub",
+                    "Zhroucená stěna nebo strop",
+                    "Suché skořápky brouků na stěnách",
+                    "Nábytek vyrobený z hrampádí",
+                    "Obrovská kresba netopýří tváře na zdi",
+                    "Rozházené stoly a židle",
+                    "Tapeta z novinových výstřižků",
+                    "Zarostlé mechem",
+                    "Nástěnná malba, nyní vybledlá",
+                    "Plošiny visící nad rychle tekoucí vodou",
+                    "Kořeny rostoucí ze zdí/podlahy/stropu",
+                    "Hnijící hromada žaludů",
+                    "Rozházené zvířecí zuby",
+                    "Lesklé obaly od bonbónů",
+                    "Dveře z hadí lebky",
+                    "Voda neustále kape ze stropu",
+                    "Nevlídná socha starověké myši",
+                    "Nerovná a hluboce popraskaná podlaha",
+                    "Bílý křemenný oltář"
+                ]
+            },
+            {
+                "typeName": "Překážka",
+                "weight": 1,
+                "creatureChance": 2,
+                "treasureChance": 1,
+                "descriptions": [
+                    "Zamčené dveře. Klíč najdete v jiné místnosti. Vykopnutí dveří bude nějakou dobru trvat a možná to někdo uslyší.",
+                    "Strmé stoupání. Bez speciálního vybavení hrozí myším vyčerpání nebo pád.",
+                    "Pokoj s východem uprostřed stropu, 15 cm od jakékoli stěny.",
+                    "Zařízení, ze kterého je slyšet nepříjemně vysoký tón. Každý tah strávený zde nebo v sousedních místnostech způsobí stav Vystrašení.",
+                    "Zřícená část tunelu s příliš malým průlezem.",
+                    "Tunel zcela zaplněný vodou.",
+                    "Široká louže bahna blokující cestu. Po ujití 15 cm způsobí stav Vyčerpání ",
+                    "Dlouhá trubka z kovu nebo platu stočená nahoru."
+                ]
+            },
+            {
+                "typeName": "Past",
+                "weight": 1,
+                "creatureChance": 1,
+                "treasureChance": 2,
+                "descriptions": [
+                    "Velké kamenné dveře povolené z rámu. Zařízení za nimi je při otočení klikou nakloní dopředu.",
+                    "Dlouhá chodba zaplavená vodou, elektrifikovaná velkou baterií skrytou ve výklenku.",
+                    "Temná místnost plná výbušného plynu. Výrazná vůně zkažených vajec. Způsobí k20 poškození při vznícení.",
+                    "Tenká nit natažená přes smrtící propast. Bezpečné, pokud cestujete pomalu, jeden po druhém.",
+                    "Jáma blokující cestu. Na dně spí had.",
+                    "Dveře se třemi klikami ve tvaru hřibů, jedna je bezpečná, ostatní jsou jedovaté. Jedovatá rukojet způsobí k12 magického poškození.",
+                    "Kruh kouzelných hub s mladou myškou uvnitř. Ti uvnitř kruhu se zoufale snaží přimět ostatní, aby vstoupili.",
+                    "Podlaha je pokryta lepidlem. K uvolnění nohy je potřeba provést záchranu na sílu."
+                ]
+            },
+            {
+                "typeName": "Hádanka",
+                "weight": 1,
+                "creatureChance": 1,
+                "treasureChance": 5,
+                "descriptions": [
+                    "Místnost s podlahou z elektrifikované měděné desky. Uprostřed je kousek cenného pokladu.",
+                    "Tři kojenecké lahve s různobarevnou tekutinou uvnitř. Samotné jsou inertní, ale smíchaný koncentrát je nebezpečný.",
+                    "Kouzelný meč zapuštěný v průhledném krystalu. Je sice velmi tvrdý, ale rozpustí se v žaludeční kyselině.",
+                    "Poklad na dně hluboké studny.",
+                    "Velká hladká ocelová mísa, dnem vzhůru. Poklad nalepený na vnitřním stropě mísy.",
+                    "Past na myši s návnadou. Mechanizmus je spojen s kameny ve zdi a při aktivaci zhroutí chodbou."
+                ]
+            },
+            {
+                "typeName": "Doupě",
+                "weight": 1,
+                "creatureChance": 5,
+                "treasureChance": 4,
+                "descriptions": [
+                    "Dočasné tábořiště",
+                    "Nedávno patřilo jinému tvorovi",
+                    "Postaveno myšmi, k uvěznění tvora",
+                    "Střeží mladé",
+                    "Trvalý domov, nově zabydlený",
+                    "Trvalý domov, komfortně zařízený"
+                ]
+            }
+        ]
+    }
 }

--- a/src/locales/cs/adventure_site_generator.json
+++ b/src/locales/cs/adventure_site_generator.json
@@ -1,0 +1,248 @@
+{
+    "title": "Delving into...",
+    "pageTitle": "Adventure Site Generator",
+    "ui": {
+        "rollButton": "Roll again"
+    },
+    "labels": {
+        "creature": "Creature",
+        "treasure": "Treasure"
+    },
+    "other": {
+        "credits": "Icons from <a href=\"https://game-icons.net/\">game-icons.net</a>. Chest by <a href=\"http://lorcblog.blogspot.com/\">Lorc</a>. Spider by <a href=\"https://twitter.com/unstoppableCarl\">Carl Olsen</a>."
+    },
+    "data": {
+        "siteName": {
+            "partA": [
+                "Black",
+                "White",
+                "Green",
+                "Blue",
+                "Red",
+                "Onyx",
+                "Emerald",
+                "Overgrown",
+                "Hidden",
+                "Charred",
+                "Burned",
+                "Lost",
+                "Broken",
+                "Golden",
+                "Bloody",
+                "Widow’s",
+                "Vine",
+                "Bone",
+                "Dry",
+                "Sodden"
+            ],
+            "partB": [
+                "Stump",
+                "Tree",
+                "Oak",
+                "Pine",
+                "Spire",
+                "Tower",
+                "Mot",
+                "Castle",
+                "Fort",
+                "Keep",
+                "Palace",
+                "Grave",
+                "Tomb",
+                "Vault",
+                "Crypt",
+                "Boneyard",
+                "Den",
+                "Sett",
+                "Lair",
+                "Burrow",
+                "Hole",
+                "Cave",
+                "Hollow",
+                "Shelter",
+                "Temple",
+                "Sanctuary",
+                "Shrine"
+            ]
+        },
+        "summary": {
+            "format": ", {{- construction}} {{- ruinAction}} <b>{{- ruin}}</b>. <b>{{- inhabitant}}</b> {{- inhabitantAction}} <b>{{- inhabitantGoal}}</b>. {{- secretHidden}} <b>{{- secret}}</b>",
+            "construction": [
+                "an <b>ancient bat cult temple</b>",
+                "a <b>long-abandoned watchtower</b>",
+                "a <b>noblemouse’s country manor</b>",
+                "a <b>hidden winter storehouse</b>",
+                "a <b>burial site of ancient mice</b>",
+                "a <b>warren dug by rabbits or foxes</b>",
+                "a <b>human house or other building</b>",
+                "a series of <b>sewer or drainage pipes</b>",
+                "a series of <b>claustrophobic ant-dug tunnels</b>",
+                "a <b>massive tree, carved out by mice</b>",
+                "a <b>wizard’s tower</b>",
+                "a <b>settlement’s grain mill</b>",
+                "a <b>rat king’s nest</b>",
+                "the <b>skeleton of a great beast</b>",
+                "a <b>witch’s academy</b>",
+                "a <b>gatehouse to the faerie realm</b>",
+                "a <b>deep mine</b>",
+                "a <b>bandit’s hideout</b>",
+                "a <b>natural cave</b>",
+                "a <b>mouse settlement</b>"
+            ],
+            "ruinAction": [
+                "ruined by",
+                "in ruins due to",
+                "desecrated by",
+                "left crumbling by",
+                "almost destroyed by",
+                "in a decrepit state due to"
+            ],
+            "ruin": [
+                "flooding",
+                "a magical mishap",
+                "age and rot",
+                "human destruction",
+                "mold",
+                "shifting between realms",
+                "attacks from a great beast",
+                "a disastrous storm",
+                "haunting spirits",
+                "mysterious abandonment",
+                "internal warfare",
+                "disease"
+            ],
+            "inhabitant": [
+                "Mice, driven mad or desperate",
+                "Mice, magically altered",
+                "Rat bandits",
+                "Creatures from a distant land",
+                "The original residents, strangely twisted",
+                "Ghostly spirits",
+                "A faerie advance guard",
+                "A foul-tempered snake",
+                "An infestation of insects",
+                "A cat lord and their servants"
+            ],
+            "inhabitantAction": [
+                "search for",
+                "protect",
+                "guard",
+                "hunt for"
+            ],
+            "inhabitantGoal": [
+                "a safe place to live or hide",
+                "a cache of fine food",
+                "a lost family or friend",
+                "ancient, valuable artworks",
+                "the last scraps in a picked-over ruin",
+                "rare alchemical mushrooms",
+                "a strange and powerful spell",
+                "a vast horde of pips"
+            ],
+            "secretHidden": [
+                "Deep within",
+                "Hidden away",
+                "Unknown to all",
+                "Beneath"
+            ],
+            "secret": [
+                "is a <b>monolith humming with arcane energy</b>",
+                "is a <b>preserved precursor beast</b>",
+                "are <b>signs of human experimentation</b>",
+                "is the <b>forgotten grave of an ancient queen</b>",
+                "is a <b>path into the veins of the earth</b>",
+                "is a <b>portal to the faerie realm</b>"
+            ]
+        },
+        "roomTypes": [
+            {
+                "typeName": "Empty",
+                "weight": 2,
+                "creatureChance": 3,
+                "treasureChance": 1,
+                "descriptions": [
+                    "Abandoned insect nest",
+                    "Cluster of mushrooms",
+                    "Collapsed wall or ceiling",
+                    "Dried bug shells on the walls",
+                    "Furniture made of repurposed trash",
+                    "Huge drawing of bat face on wall",
+                    "Mess of tables and chairs",
+                    "Newspaper clipping wallpaper",
+                    "Overgrown with moss",
+                    "Painted mural, now faded",
+                    "Platforms hanging over rapidly flowing water",
+                    "Roots bursting out of walls/floor/ceiling",
+                    "Rotting pile of acorns",
+                    "Scattering of animal teeth",
+                    "Shiny candy-wrapper banners ",
+                    "Snake skull doorway",
+                    "Steady drip of water from ceiling",
+                    "Stern statue of an ancient mouse",
+                    "Uneven and deeply cracked floor",
+                    "White quartz altar"
+                ]
+            },
+            {
+                "typeName": "Obstacle",
+                "weight": 1,
+                "creatureChance": 2,
+                "treasureChance": 1,
+                "descriptions": [
+                    "Locked door. Key can be found in another room. Knocking the door down takes time and makes noise.",
+                    "Steep climb. Without special equipment, mice risk exhaustion or falling.",
+                    "Room with an exit in the centre of the roof, 6\" away from any wall.",
+                    "Device that creates an high-pitched scream. Each Turn spent here or in adjacent rooms gives Frightened Condition.",
+                    "Caved-in section of tunnel, leaving a gap too small to crawl through.",
+                    "Tunnel completely filled with water.",
+                    "Wide, deep puddle of mud blocking the way. Gives an Exhausted Condition per 6\" traveled.",
+                    "Long, smooth, upwards sloping metal or plastic tube."
+                ]
+            },
+            {
+                "typeName": "Trap",
+                "weight": 1,
+                "creatureChance": 1,
+                "treasureChance": 2,
+                "descriptions": [
+                    "Large stone door, chiseled loose from frame. Device behind the door tips it forward when handle is turned.",
+                    "Long hallway flooded with water, electrified by large battery in an alcove.",
+                    "Dark room filled with noxious, explosive gas. Distinct smell of rotten eggs. d20 damage if ignited.",
+                    "Thin thread stretched across deadly fall. Safe if traveling slowly, one at a time.",
+                    "Pit blocking the way. A snake is asleep at the bottom.",
+                    "Door with three handles in the shape of mushrooms, one safe, the others poison. Poison handles deal d12 magical damage.",
+                    "Circle of enchanted mushrooms, with a young mouse inside. Those within try desperately to get others to enter.",
+                    "Floor is covered in sticky glue. Requires a STR save to break a foot loose."
+                ]
+            },
+            {
+                "typeName": "Puzzle",
+                "weight": 1,
+                "creatureChance": 1,
+                "treasureChance": 5,
+                "descriptions": [
+                    "Room with a floor made of an electrified copper plate. A piece of valuable treasure sits in the centre.",
+                    "Three feeding bottles with different-colored liquid inside. Each is inert individually but powerful/dangerous when mixed.",
+                    "A crystal, a magic sword embedded inside. The crystal is very hard, but will dissolve in stomach acid.",
+                    "Treasure is at the bottom of deep well. ",
+                    "Large smooth steel bowl, upside down. Treasure taped to the inside ceiling of the bowl.",
+                    "Baited mousetrap. The lever is wired to a stone in the wall and will collapse the corridor if triggered"
+                ]
+            },
+            {
+                "typeName": "Lair",
+                "weight": 1,
+                "creatureChance": 5,
+                "treasureChance": 4,
+                "descriptions": [
+                    "Temporary encampment",
+                    "Recently taken from another creature",
+                    "Built by mice to hold the creature",
+                    "Protecting young",
+                    "Permanent home, newly settled",
+                    "Permanent home, comfortably appointed"
+                ]
+            }
+        ]
+    }
+}

--- a/src/locales/cs/item_card_studio.json
+++ b/src/locales/cs/item_card_studio.json
@@ -5,7 +5,7 @@
         "template": "Šablona",
         "name": "Název",
         "damageOrDef": "Zranění/Obrana",
-        "mechanic": "Mechanic",
+        "mechanic": "Mechanika",
         "clear": "Odstranění",
         "class": "Třída",
         "usage": "Použití",
@@ -47,9 +47,9 @@
             "Branch": "Větev",
             "Dagger": "Dýka",
             "Needle": "Jehla",
-            "Axe": "Sekera",
+            "Axe": "Sekyrka",
             "Sword": "Meč",
-            "Mace": "Palcát",
+            "Mace": "Řemdich",
             "Warhammer": "Válečné kladivo",
             "Spear": "Kopí",
             "Hookarm": "Hákopí",
@@ -74,9 +74,9 @@
         "sheetNamePlaceholder": "Název stránky"
     },
     "printSheet": {
-        "instructionsTitle": "Instrukce (these won't print)",
-        "instructions": "Ve svém prohlížeči vyberte možnost <strong>Tisk</strong> nebo <strong>Exportovat jako PDF</strong>. Ujistěte se, že je přiblížení nastaveno na 100 %.",
-        "returnButton": "Vrátit se ke tvorbě kartiček vybavení"
+        "instructionsTitle": "Instrukce (nejsou součástí tisku)",
+        "instructions": "Ve svém prohlížeči vyberte možnost <strong>Tisk</strong> nebo <strong>Exportovat jako PDF</strong>. Ujistěte se, že je přiblížení nastaveno na 100%.",
+        "returnButton": "Vrátit se k tvorbě kartiček vybavení"
     },
     "itemTemplates": [
         {

--- a/src/locales/cs/item_card_studio.json
+++ b/src/locales/cs/item_card_studio.json
@@ -1,0 +1,228 @@
+{
+    "title": "Kartičky vybavení",
+    "pageTitle": "Tvorba kartiček vybavení",
+    "controlPanel": {
+        "template": "Šablona",
+        "name": "Název",
+        "damageOrDef": "Zranění/Obrana",
+        "mechanic": "Mechanic",
+        "clear": "Odstranění",
+        "class": "Třída",
+        "usage": "Použití",
+        "star": "Hvězda",
+        "image": "Obrázek",
+        "width": "Šířka",
+        "height": "Výška",
+        "background": "Pozadí",
+        "foreground": "Text",
+        "divider": "Oddělovač",
+        "border": "Okraj",
+        "resolution": "Rozlišení",
+        "resolutionOptions": [
+            {
+                "dpi": 100,
+                "label": "Nízké"
+            },
+            {
+                "dpi": 300,
+                "label": "Vysoké"
+            },
+            {
+                "dpi": 600,
+                "label": "Extra vysoké"
+            }
+        ],
+        "saveToSheetButton": "Ulož na stránku",
+        "saveImageButton": "Ulož obrázek",
+        "cardImages": {
+            "None": "Žádný",
+            "Custom...": "Vlastní...",
+            "Torch": "Pochodně",
+            "Lantern": "Lucerna",
+            "Electric lantern": "Elektrická lampa",
+            "Pip purse": "Váček na ďobky",
+            "Quiver": "Šípy",
+            "Rations": "Zásoby",
+            "Stones": "Kamení",
+            "Branch": "Větev",
+            "Dagger": "Dýka",
+            "Needle": "Jehla",
+            "Axe": "Sekera",
+            "Sword": "Meč",
+            "Mace": "Palcát",
+            "Warhammer": "Válečné kladivo",
+            "Spear": "Kopí",
+            "Hookarm": "Hákopí",
+            "Bow": "Luk",
+            "Sling": "Prak",
+            "Heavy armour": "Těžká zbroj",
+            "Light armour": "Lehká zbroj",
+            "Spell 1": "Kouzlo 1",
+            "Spell 2": "Kouzlo 2",
+            "Spell 3": "Kouzlo 3",
+            "Spell 4": "Kouzlo 4",
+            "Spell 5": "Kouzlo 5",
+            "Spell (blank)": "Kouzlo (prázdné)"
+        }
+    },
+    "sheet": {
+        "saveSheetButton": "Uložit stránku",
+        "loadSheetButton": "Nahrát stránku",
+        "loadSheetButton_hasItems": "Nahrát další předměty",
+        "clearSheetButton": "Smazat stránku",
+        "printSheetButton": "Tisk",
+        "sheetNamePlaceholder": "Název stránky"
+    },
+    "printSheet": {
+        "instructionsTitle": "Instrukce (these won't print)",
+        "instructions": "Ve svém prohlížeči vyberte možnost <strong>Tisk</strong> nebo <strong>Exportovat jako PDF</strong>. Ujistěte se, že je přiblížení nastaveno na 100 %.",
+        "returnButton": "Vrátit se ke tvorbě kartiček vybavení"
+    },
+    "itemTemplates": [
+        {
+            "id": "item",
+            "name": "Předmět",
+            "template": {
+                "name": "Nový předmět",
+                "usage": 3,
+                "damage": "",
+                "mechanicDetail": "",
+                "clearDetail": "",
+                "classDetail": "",
+                "image": "",
+                "backgroundColor": "#ffffff",
+                "foregroundColor": "#000000",
+                "width": 1,
+                "height": 1,
+                "divider": true,
+                "border": true,
+                "star": false
+            },
+            "controls": {
+                "name": true,
+                "usage": true,
+                "image": true
+            }
+        },
+        {
+            "id": "weapon",
+            "name": "Zbraň",
+            "template": {
+                "name": "Meč",
+                "usage": 3,
+                "damage": "k6/k8",
+                "mechanicDetail": "",
+                "clearDetail": "",
+                "classDetail": "Střední",
+                "image": "Sword",
+                "__image_comment__": "Don't translate the image name in the templates, they're used as lookup keys",
+                "backgroundColor": "#ffffff",
+                "foregroundColor": "#000000",
+                "width": 1,
+                "height": 1,
+                "divider": true,
+                "border": true,
+                "star": false
+            },
+            "controls": {
+                "name": true,
+                "usage": true,
+                "damage": true,
+                "classDetail": true,
+                "image": true
+            }
+        },
+        {
+            "id": "armour",
+            "name": "Zbroj",
+            "template": {
+                "name": "Těžká zbroj",
+                "usage": 3,
+                "damage": "1 obr.",
+                "mechanicDetail": "",
+                "clearDetail": "",
+                "classDetail": "Těžká",
+                "image": "Heavy armour",
+                "backgroundColor": "#ffffff",
+                "foregroundColor": "#000000",
+                "width": 1,
+                "height": 2,
+                "divider": true,
+                "border": true,
+                "star": false
+            },
+            "controls": {
+                "name": true,
+                "usage": true,
+                "damage": true,
+                "classDetail": true,
+                "image": true
+            }
+        },
+        {
+            "id": "spell",
+            "name": "Kouzlo",
+            "template": {
+                "name": "Zahojení",
+                "usage": 3,
+                "damage": "",
+                "mechanicDetail": "",
+                "clearDetail": "",
+                "classDetail": "",
+                "image": "Spell 1",
+                "backgroundColor": "#ffffff",
+                "foregroundColor": "#000000",
+                "width": 1,
+                "height": 1,
+                "divider": true,
+                "border": true,
+                "star": true
+            },
+            "controls": {
+                "name": true,
+                "usage": true,
+                "image": true
+            }
+        },
+        {
+            "id": "condition",
+            "name": "Stav",
+            "template": {
+                "name": "Poranění",
+                "usage": 0,
+                "damage": "",
+                "mechanicDetail": "Nevýhoda při hodech na sílu a mrštnost",
+                "clearDetail": "po úplném odpočinku",
+                "classDetail": "",
+                "image": "",
+                "backgroundColor": "#ff4444",
+                "foregroundColor": "#000000",
+                "width": 1,
+                "height": 1,
+                "divider": false,
+                "border": true,
+                "star": false
+            },
+            "controls": {
+                "name": true,
+                "mechanicDetail": true,
+                "clearDetail": true
+            }
+        },
+        {
+            "id": "freeform",
+            "name": "Vlastní",
+            "template": {},
+            "controls": {
+                "name": true,
+                "usage": true,
+                "damage": true,
+                "mechanicDetail": true,
+                "clearDetail": true,
+                "classDetail": true,
+                "star": true,
+                "image": true
+            }
+        }
+    ]
+}

--- a/src/locales/cs/mouse_generator.json
+++ b/src/locales/cs/mouse_generator.json
@@ -1,680 +1,1124 @@
 {
-    "title": "Chrabrý myší dobrodruh...",
-    "pageTitle": "Vytvoř myš",
-    "ui": {
-        "rollButton": "Hoď znovu"
-    },
-    "fields": {
-        "name": "Jméno",
-        "background": "Původ",
-        "birthsign": "Rodné znamení",
-        "disposition": "Povaha",
-        "coat": "Srst",
-        "physicalDetail": "Výrazný rys",
-        "str": "Síla",
-        "dex": "Mrš.",
-        "wil": "Vůle",
-        "hp": "BO",
-        "max": "Maximum",
-        "current": "Aktuální",
-        "inventory": "Inventář",
-        "additionalItems": "Další vybavení",
-        "pips": "Ďobky"
-    },
-    "data": {
-        "standardItems": [
-            {
-                "name": "Zásoby"
-            },
-            {
-                "name": "Pochodeň"
-            },
-            {
-                "name": "Zbraň dle tvého výběru",
-                "notCard": true
-            }
-        ],
-        "backgrounds": [
-            {
-                "title": "Test subject",
-                "items": [
-                    {
-                        "name": "Kouzelná střela",
-                        "type": "Kouzlo"
-                    },
-                    {
-                        "name": "Olověný plášť",
-                        "type": "Těžká zbroj",
-                        "shape": "tall",
-                        "def": "1 obr."
-                    }
-                ]
-            },
-            {
-                "title": "Kuchyňský slídil",
-                "items": [
-                    {
-                        "name": "Štít a kabátec",
-                        "type": "Lehká zbroj",
-                        "shape": "wide",
-                        "def": "1 obr."
-                    },
-                    {
-                        "name": "Hrnce"
-                    }
-                ]
-            },
-            {
-                "title": "Uprchlík z klece",
-                "items": [
-                    {
-                        "name": "Srozumitelnost",
-                        "type": "Kouzlo"
-                    },
-                    {
-                        "name": "Láhev mléka"
-                    }
-                ]
-            },
-            {
-                "title": "Čarodějnice",
-                "items": [
-                    {
-                        "name": "Zahojení",
-                        "type": "Kouzlo"
-                    },
-                    {
-                        "name": "Vonná tyčka"
-                    }
-                ]
-            },
-            {
-                "title": "Kožešník",
-                "items": [
-                    {
-                        "name": "Štít a kabátec",
-                        "type": "Lehká zbroj",
-                        "shape": "wide",
-                        "def": "1 obr."
-                    },
-                    {
-                        "name": "Silné nůžky"
-                    }
-                ]
-            },
-            {
-                "title": "Pouliční rváč",
-                "items": [
-                    {
-                        "name": "Dýka",
-                        "type": "Lehká",
-                        "attack": "k6"
-                    },
-                    {
-                        "name": "Láhev kávy"
-                    }
-                ]
-            },
-            {
-                "title": "Žebravý kněz",
-                "items": [
-                    {
-                        "name": "Zotavení",
-                        "type": "Kouzlo"
-                    },
-                    {
-                        "name": "Svatý symbol"
-                    }
-                ]
-            },
-            {
-                "title": "Honák brouků",
-                "items": [
-                    {
-                        "name": "Pomocník: Věrný brouk",
-                        "notCard": true
-                    },
-                    {
-                        "name": "Tyč, 15 cm"
-                    }
-                ]
-            },
-            {
-                "title": "Sládek",
-                "items": [
-                    {
-                        "name": "Pomocník: Opilý světlonoš",
-                        "notCard": true
-                    },
-                    {
-                        "name": "Soudek piva"
-                    }
-                ]
-            },
-            {
-                "title": "Rybář",
-                "items": [
-                    {
-                        "name": "Jehla",
-                        "type": "Lehká",
-                        "attack": "k6"
-                    },
-                    {
-                        "name": "Síť"
-                    }
-                ]
-            },
-            {
-                "title": "Kovář",
-                "items": [
-                    {
-                        "name": "Kladivo",
-                        "type": "Střední",
-                        "attack": "k6/k8"
-                    },
-                    {
-                        "name": "Pilník na železo"
-                    }
-                ]
-            },
-            {
-                "title": "Dráteník",
-                "items": [
-                    {
-                        "name": "Drát, klubko"
-                    },
-                    {
-                        "name": "Elektrická lampa",
-                        "usage": 6
-                    }
-                ]
-            },
-            {
-                "title": "Dřevorubec",
-                "items": [
-                    {
-                        "name": "Sekera",
-                        "type": "Střední",
-                        "attack": "k6/k8"
-                    },
-                    {
-                        "name": "Motouz, klubko"
-                    }
-                ]
-            },
-            {
-                "title": "Člen netopýřího kultu",
-                "items": [
-                    {
-                        "name": "Tma",
-                        "type": "Kouzlo"
-                    },
-                    {
-                        "name": "Pytlík netopýřích zubů"
-                    }
-                ]
-            },
-            {
-                "title": "Horník v cínovém dole",
-                "items": [
-                    {
-                        "name": "Krumpáč",
-                        "type": "Střední",
-                        "attack": "k6/k8"
-                    },
-                    {
-                        "name": "Lucerna"
-                    }
-                ]
-            },
-            {
-                "title": "Sběrač odpadků",
-                "items": [
-                    {
-                        "name": "Hák na odpadky",
-                        "type": "Těžká",
-                        "attack": "k10",
-                        "shape": "tall"
-                    },
-                    {
-                        "name": "Zrcátko"
-                    }
-                ]
-            },
-            {
-                "title": "Stěnolezec",
-                "items": [
-                    {
-                        "name": "Rybářský háček"
-                    },
-                    {
-                        "name": "Nit, cívka"
-                    }
-                ]
-            },
-            {
-                "title": "Kupec",
-                "items": [
-                    {
-                        "name": "Pomocník: Tažná krysa",
-                        "notCard": true
-                    },
-                    {
-                        "name": "Směnka od šlechtice na 20 ď"
-                    }
-                ]
-            },
-            {
-                "title": "Vorař",
-                "items": [
-                    {
-                        "name": "Kladivo",
-                        "type": "Střední",
-                        "attack": "k6/k8"
-                    },
-                    {
-                        "name": "Dřevěné klíny"
-                    }
-                ]
-            },
-            {
-                "title": "Honák žížal",
-                "items": [
-                    {
-                        "name": "Tyč, 15 cm"
-                    },
-                    {
-                        "name": "Mýdlo"
-                    }
-                ]
-            },
-            {
-                "title": "Vlaštovkář",
-                "items": [
-                    {
-                        "name": "Rybářský háček"
-                    },
-                    {
-                        "name": "Ochranné brýle"
-                    }
-                ]
-            },
-            {
-                "title": "Kanálník",
-                "items": [
-                    {
-                        "name": "Pilník na železo"
-                    },
-                    {
-                        "name": "Nit, cívka"
-                    }
-                ]
-            },
-            {
-                "title": "Žalářník",
-                "items": [
-                    {
-                        "name": "Kopí",
-                        "type": "Těžká",
-                        "attack": "k10",
-                        "shape": "tall"
-                    },
-                    {
-                        "name": "Řetěz, 15 cm"
-                    }
-                ]
-            },
-            {
-                "title": "Pěstitel hub",
-                "items": [
-                    {
-                        "name": "Sušené houby"
-                    },
-                    {
-                        "name": "Maska proti spórám"
-                    }
-                ]
-            },
-            {
-                "title": "Stavitel hrází",
-                "items": [
-                    {
-                        "name": "Lopata"
-                    },
-                    {
-                        "name": "Dřevěné klíny"
-                    }
-                ]
-            },
-            {
-                "title": "Kartograf",
-                "items": [
-                    {
-                        "name": "Brk a inkoust"
-                    },
-                    {
-                        "name": "Kompas"
-                    }
-                ]
-            },
-            {
-                "title": "Vykradač pastiček",
-                "items": [
-                    {
-                        "name": "Kus sýra"
-                    },
-                    {
-                        "name": "Lepidlo"
-                    }
-                ]
-            },
-            {
-                "title": "Tulák",
-                "items": [
-                    {
-                        "name": "Stan",
-                        "shape": "tall"
-                    },
-                    {
-                        "name": "Mapa k pokladu, pochybná"
-                    }
-                ]
-            },
-            {
-                "title": "Pěstitel obilí",
-                "items": [
-                    {
-                        "name": "Kopí",
-                        "type": "Těžká",
-                        "attack": "k10",
-                        "shape": "tall"
-                    },
-                    {
-                        "name": "Píšťalka"
-                    }
-                ]
-            },
-            {
-                "title": "Poslíček",
-                "items": [
-                    {
-                        "name": "Deka"
-                    },
-                    {
-                        "name": "Dokumenty, zapečetěné"
-                    }
-                ]
-            },
-            {
-                "title": "Trubadúr",
-                "items": [
-                    {
-                        "name": "Hudební nástroj"
-                    },
-                    {
-                        "name": "Maskovací sada"
-                    }
-                ]
-            },
-            {
-                "title": "Hazardní hráč",
-                "items": [
-                    {
-                        "name": "Zatížené kostky"
-                    },
-                    {
-                        "name": "Zrcátko"
-                    }
-                ]
-            },
-            {
-                "title": "Sběrač mízy",
-                "items": [
-                    {
-                        "name": "Vědro"
-                    },
-                    {
-                        "name": "Dřevěné klíny"
-                    }
-                ]
-            },
-            {
-                "title": "Včelař",
-                "items": [
-                    {
-                        "name": "Sklenice medu"
-                    },
-                    {
-                        "name": "Síť"
-                    }
-                ]
-            },
-            {
-                "title": "Knihovník",
-                "items": [
-                    {
-                        "name": "Útržek ze starodávné knihy"
-                    },
-                    {
-                        "name": "Brk a inkoust"
-                    }
-                ]
-            },
-            {
-                "title": "Zchudlý šlechtic",
-                "items": [
-                    {
-                        "name": "Plstěný klobouk"
-                    },
-                    {
-                        "name": "Parfém"
-                    }
-                ]
-            }
-        ],
-        "firstNames": [
-            "Ada",
-            "Agáta",
-            "Akácie",
-            "Aloe",
-            "Ambrož",
-            "Anežka",
-            "Anýz",
-            "Apríl",
-            "Astra",
-            "Augustín",
-            "Azalka",
-            "Bazalka",
-            "Berylie",
-            "Bobek",
-            "Bodlák",
-            "Bříz",
-            "Čedar",
-            "Čekanka",
-            "Devětsil",
-            "Edmund",
-            "Eidam",
-            "Elza",
-            "Emil",
-            "Erina",
-            "Estragon",
-            "Fenykl",
-            "Fialka",
-            "Filip",
-            "Františka",
-            "Gouda",
-            "Grácie",
-            "Gvendolína",
-            "Habrovec",
-            "Háta",
-            "Hložek",
-            "Horácio",
-            "Hyacint",
-            "Iris",
-            "Jalovec",
-            "Janek",
-            "Jasan",
-            "Jaspis",
-            "Jeřabinka",
-            "Jílovec",
-            "Jiřička",
-            "Karmína",
-            "Klára",
-            "Kmínek",
-            "Konrád",
-            "Kostřava",
-            "Krokus",
-            "Kuklík",
-            "Květa",
-            "Levandule",
-            "Lilie",
-            "Líska",
-            "Lorenz",
-            "Magnolie",
-            "Majoránka",
-            "Makovec",
-            "Máslena",
-            "Meduňka",
-            "Měsíček",
-            "Muškát",
-            "Myrta",
-            "Niva",
-            "Nora",
-            "Okřál",
-            "Oliver",
-            "Olivie",
-            "Olša",
-            "Opál",
-            "Otýlie",
-            "Pelyňka",
-            "Pepřík",
-            "Perla",
-            "Rípčíp",
-            "Rokfór",
-            "Routa",
-            "Rozmarín",
-            "Rulík",
-            "Řebřík",
-            "Sedmikráska",
-            "Slídie",
-            "Smaragd",
-            "Svízel",
-            "Šafrán",
-            "Šimon",
-            "Šípek",
-            "Šťavel",
-            "Tis",
-            "Vavřinec",
-            "Vilík",
-            "Višňa",
-            "Vlnka",
-            "Vrbena",
-            "Vřesena",
-            "Vřesík",
-            "Zuzanka",
-            "Žitmil"
-        ],
-        "familyNames": [
-            "Bílý/Bílá",
-            "Černý/Černá",
-            "Čihař/Čihařová",
-            "Darček/Darčeková",
-            "Durman/Durmanová",
-            "Hrabal/Hrabalová",
-            "Chalva/Chalvová",
-            "Jařinka/Jařinková",
-            "Jeleňák/Jeleňáková",
-            "Jeseň/Jeseňová",
-            "Katzenreiser/Katzenreiserová",
-            "Máselník/Máselníková",
-            "Píp/Pípová",
-            "Řešetlák/Řešetláková",
-            "Semínko/Semínková",
-            "Sníh/Sněhová",
-            "Strážný/Strážná",
-            "Trnka/Trnková",
-            "Urobil/Urobilová",
-            "Žvanil/Žvanilová"
-        ],
-        "birthSigns": [
-            {
-                "title": "Hvězda",
-                "disposition": "Statečná / zbrklá"
-            },
-            {
-                "title": "Kolo",
-                "disposition": "Pracovitá / nenápaditá"
-            },
-            {
-                "title": "Žalud",
-                "disposition": "Zvědavá / paličatá"
-            },
-            {
-                "title": "Bouřka",
-                "disposition": "Štědrá / popudlivá"
-            },
-            {
-                "title": "Měsíc",
-                "disposition": "Moudrá / záhadná"
-            },
-            {
-                "title": "Matka",
-                "disposition": "Pečující / ustaraná"
-            }
-        ],
-        "coatColors": [
-            "Čokoládová",
-            "Černá",
-            "Bílá",
-            "Světle hnědá",
-            "Šedá",
-            "Namodralá"
-        ],
-        "coatPatterns": [
-            "jednolitá",
-            "mourovatá",
-            "strakatá",
-            "pruhovaná",
-            "tečkovaná",
-            "skvrnitá"
-        ],
-        "physicalDetail": [
-            "Tělo plné jizev",
-            "Korpulentní tělo",
-            "Vychrtlé tělo",
-            "Klackovité tělo",
-            "Drobné tělíčko",
-            "Rozložité tělo",
-            "Válečné malování",
-            "Cizokrajné oblečení",
-            "Elegantní oblečení",
-            "Záplatované oblečení",
-            "Módní oblečení",
-            "Neprané oblečení",
-            "Useknuté ucho",
-            "Neforemný obličej",
-            "Krásný obličej",
-            "Baculatý obličej",
-            "Jemné rysy v obličeji",
-            "Protáhlý obličej",
-            "Načesaná srst",
-            "Dredy",
-            "Nabarvená srst",
-            "Oholená srst",
-            "Kudrnatá srst",
-            "Sametová srst",
-            "Oči temné jako noc",
-            "Páska přes oko",
-            "Krvavě rudé oči",
-            "Moudrý pohled",
-            "Pronikavý pohled",
-            "Blyštivé oči",
-            "Zastřižený ocásek",
-            "Ocásek jako bič",
-            "Chocholatý ocásek",
-            "Pahýl ocásku",
-            "Chápavý ocásek",
-            "Zakroucený ocásek"
-        ]
-    }
+	"title": "Chrabrý myší dobrodruh...",
+	"pageTitle": "Vytvoř myš",
+	"ui": {
+		"rollButton": "Hoď znovu"
+	},
+	"fields": {
+		"name": "Jméno",
+		"background": "Původ",
+		"birthsign": "Rodné znamení",
+		"disposition": "Povaha",
+		"coat": "Srst",
+		"physicalDetail": "Výrazný rys",
+		"str": "Síla",
+		"dex": "Mrš.",
+		"wil": "Vůle",
+		"hp": "BO",
+		"max": "Maximum",
+		"current": "Aktuální",
+		"inventory": "Inventář",
+		"additionalItems": "Další vybavení",
+		"pips": "Ďobky"
+	},
+	"data": {
+		"standardItems": [
+			{
+				"name": "Zásoby"
+			},
+			{
+				"name": "Pochodeň"
+			},
+			{
+				"name": "Zbraň dle tvého výběru",
+				"notCard": true
+			}
+		],
+		"backgrounds": [
+			{
+				"title": {
+					"background_firstName=male": "Pokusný myšák",
+					"background": "Pokusná myš"
+				},
+				"items": [
+					{
+						"name": "Kouzelná střela",
+						"type": "Kouzlo"
+					},
+					{
+						"name": "Olověný plášť",
+						"type": "Těžká zbroj",
+						"shape": "tall",
+						"def": "1 obr."
+					}
+				]
+			},
+			{
+				"title": "Kuchyňský slídil",
+				"items": [
+					{
+						"name": "Štít a kabátec",
+						"type": "Lehká zbroj",
+						"shape": "wide",
+						"def": "1 obr."
+					},
+					{
+						"name": "Hrnce"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=male": "Uprchlík z klece",
+					"background": "Uprchlice z klece"
+				},
+				"items": [
+					{
+						"name": "Srozumitelnost",
+						"type": "Kouzlo"
+					},
+					{
+						"name": "Láhev mléka"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=male": "Čaroděj",
+					"background": "Čarodějnice"
+				},
+				"items": [
+					{
+						"name": "Zahojení",
+						"type": "Kouzlo"
+					},
+					{
+						"name": "Vonná tyčka"
+					}
+				]
+			},
+			{
+				"title": "Kožešník",
+				"items": [
+					{
+						"name": "Štít a kabátec",
+						"type": "Lehká zbroj",
+						"shape": "wide",
+						"def": "1 obr."
+					},
+					{
+						"name": "Silné nůžky"
+					}
+				]
+			},
+			{
+				"title": "Pouliční rváč",
+				"items": [
+					{
+						"name": "Dýka",
+						"type": "Lehká",
+						"attack": "k6"
+					},
+					{
+						"name": "Láhev kávy"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Žebravá kněžka",
+					"background": "Žebravý kněz"
+				},
+				"items": [
+					{
+						"name": "Zotavení",
+						"type": "Kouzlo"
+					},
+					{
+						"name": "Svatý symbol"
+					}
+				]
+			},
+			{
+				"title": "Honák brouků",
+				"items": [
+					{
+						"name": "Pomocník: Věrný brouk",
+						"notCard": true
+					},
+					{
+						"name": "Tyč, 15 cm"
+					}
+				]
+			},
+			{
+				"title": "Sládek",
+				"items": [
+					{
+						"name": "Pomocník: Opilý světlonoš",
+						"notCard": true
+					},
+					{
+						"name": "Soudek piva"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Rybářka",
+					"background": "Rybář"
+				},
+				"items": [
+					{
+						"name": "Jehla",
+						"type": "Lehká",
+						"attack": "k6"
+					},
+					{
+						"name": "Síť"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Kovářka",
+					"background": "Kovář"
+				},
+				"items": [
+					{
+						"name": "Kladivo",
+						"type": "Střední",
+						"attack": "k6/k8"
+					},
+					{
+						"name": "Pilník na železo"
+					}
+				]
+			},
+			{
+				"title": "Dráteník",
+				"items": [
+					{
+						"name": "Drát, klubko"
+					},
+					{
+						"name": "Elektrická lampa",
+						"usage": 6
+					}
+				]
+			},
+			{
+				"title": "Dřevorubec",
+				"items": [
+					{
+						"name": "Sekera",
+						"type": "Střední",
+						"attack": "k6/k8"
+					},
+					{
+						"name": "Motouz, klubko"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Členka netopýřího kultu",
+					"background": "Člen netopýřího kultu"
+				},
+				"items": [
+					{
+						"name": "Tma",
+						"type": "Kouzlo"
+					},
+					{
+						"name": "Pytlík netopýřích zubů"
+					}
+				]
+			},
+			{
+				"title": "Horník v cínovém dole",
+				"items": [
+					{
+						"name": "Krumpáč",
+						"type": "Střední",
+						"attack": "k6/k8"
+					},
+					{
+						"name": "Lucerna"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Sběračka odpadků",
+					"background": "Sběrač odpadků"
+				},
+				"items": [
+					{
+						"name": "Hák na odpadky",
+						"type": "Těžká",
+						"attack": "k10",
+						"shape": "tall"
+					},
+					{
+						"name": "Zrcátko"
+					}
+				]
+			},
+			{
+				"title": "Stěnolezec",
+				"items": [
+					{
+						"name": "Rybářský háček"
+					},
+					{
+						"name": "Nit, cívka"
+					}
+				]
+			},
+			{
+				"title": "Kupec",
+				"items": [
+					{
+						"name": "Pomocník: Tažná krysa",
+						"notCard": true
+					},
+					{
+						"name": "Směnka od šlechtice na 20 ď"
+					}
+				]
+			},
+			{
+				"title": "Vorař",
+				"items": [
+					{
+						"name": "Kladivo",
+						"type": "Střední",
+						"attack": "k6/k8"
+					},
+					{
+						"name": "Dřevěné klíny"
+					}
+				]
+			},
+			{
+				"title": "Honák žížal",
+				"items": [
+					{
+						"name": "Tyč, 15 cm"
+					},
+					{
+						"name": "Mýdlo"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Vlaštovkářka",
+					"background": "Vlaštovkář"
+				},
+				"items": [
+					{
+						"name": "Rybářský háček"
+					},
+					{
+						"name": "Ochranné brýle"
+					}
+				]
+			},
+			{
+				"title": "Kanálník",
+				"items": [
+					{
+						"name": "Pilník na železo"
+					},
+					{
+						"name": "Nit, cívka"
+					}
+				]
+			},
+			{
+				"title": "Žalářník",
+				"items": [
+					{
+						"name": "Kopí",
+						"type": "Těžká",
+						"attack": "k10",
+						"shape": "tall"
+					},
+					{
+						"name": "Řetěz, 15 cm"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Pěstitelka hub",
+					"background": "Pěstitel hub"
+				},
+				"items": [
+					{
+						"name": "Sušené houby"
+					},
+					{
+						"name": "Maska proti spórám"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Stavitelka hrází",
+					"background": "Stavitel hrází"
+				},
+				"items": [
+					{
+						"name": "Lopata"
+					},
+					{
+						"name": "Dřevěné klíny"
+					}
+				]
+			},
+			{
+				"title": "Kartograf",
+				"items": [
+					{
+						"name": "Brk a inkoust"
+					},
+					{
+						"name": "Kompas"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Vykradačka pastiček",
+					"background": "Vykradač pastiček"
+				},
+				"items": [
+					{
+						"name": "Kus sýra"
+					},
+					{
+						"name": "Lepidlo"
+					}
+				]
+			},
+			{
+				"title": "Tulák",
+				"items": [
+					{
+						"name": "Stan",
+						"shape": "tall"
+					},
+					{
+						"name": "Mapa k pokladu, pochybná"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Pěstitelka obilí",
+					"background": "Pěstitel obilí"
+				},
+				"items": [
+					{
+						"name": "Kopí",
+						"type": "Těžká",
+						"attack": "k10",
+						"shape": "tall"
+					},
+					{
+						"name": "Píšťalka"
+					}
+				]
+			},
+			{
+				"title": "Poslíček",
+				"items": [
+					{
+						"name": "Deka"
+					},
+					{
+						"name": "Dokumenty, zapečetěné"
+					}
+				]
+			},
+			{
+				"title": "Trubadúr",
+				"items": [
+					{
+						"name": "Hudební nástroj"
+					},
+					{
+						"name": "Maskovací sada"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Hazardní hráčka",
+					"background": "Hazardní hráč"
+				},
+				"items": [
+					{
+						"name": "Zatížené kostky"
+					},
+					{
+						"name": "Zrcátko"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Sběračka mízy",
+					"background": "Sběrač mízy"
+				},
+				"items": [
+					{
+						"name": "Vědro"
+					},
+					{
+						"name": "Dřevěné klíny"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Včelařka",
+					"background": "Včelař"
+				},
+				"items": [
+					{
+						"name": "Sklenice medu"
+					},
+					{
+						"name": "Síť"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Knihovnice",
+					"background": "Knihovník"
+				},
+				"items": [
+					{
+						"name": "Útržek ze starodávné knihy"
+					},
+					{
+						"name": "Brk a inkoust"
+					}
+				]
+			},
+			{
+				"title": {
+					"background_firstName=female": "Zchudlá šlechtična",
+					"background": "Zchudlý šlechtic"
+				},
+				"items": [
+					{
+						"name": "Plstěný klobouk"
+					},
+					{
+						"name": "Parfém"
+					}
+				]
+			}
+		],
+		"firstNames": [
+			{
+				"firstName": "Ada",
+				"context": "female"
+			},
+			{
+				"firstName": "Agáta",
+				"context": "female"
+			},
+			{
+				"firstName": "Akácie",
+				"context": "female"
+			},
+			{
+				"firstName": "Aloe",
+				"context": "female"
+			},
+			{
+				"firstName": "Ambrož",
+				"context": "male"
+			},
+			{
+				"firstName": "Anežka",
+				"context": "female"
+			},
+			{
+				"firstName": "Anýz",
+				"context": "male"
+			},
+			{
+				"firstName": "Apríl",
+				"context": "male"
+			},
+			{
+				"firstName": "Astra",
+				"context": "female"
+			},
+			{
+				"firstName": "Augustín",
+				"context": "male"
+			},
+			{
+				"firstName": "Azalka",
+				"context": "female"
+			},
+			{
+				"firstName": "Bazalka",
+				"context": "female"
+			},
+			{
+				"firstName": "Berylie",
+				"context": "female"
+			},
+			{
+				"firstName": "Bobek",
+				"context": "male"
+			},
+			{
+				"firstName": "Bodlák",
+				"context": "male"
+			},
+			{
+				"firstName": "Bříz",
+				"context": "male"
+			},
+			{
+				"firstName": "Bříza",
+				"context": "female"
+			},
+			{
+				"firstName": "Čedar",
+				"context": "male"
+			},
+			{
+				"firstName": "Čekanka",
+				"context": "female"
+			},
+			{
+				"firstName": "Devětsil",
+				"context": "male"
+			},
+			{
+				"firstName": "Edmund",
+				"context": "male"
+			},
+			{
+				"firstName": "Eidam",
+				"context": "male"
+			},
+			{
+				"firstName": "Elza",
+				"context": "female"
+			},
+			{
+				"firstName": "Emil",
+				"context": "male"
+			},
+			{
+				"firstName": "Erina",
+				"context": "female"
+			},
+			{
+				"firstName": "Estragon",
+				"context": "male"
+			},
+			{
+				"firstName": "Fenykl",
+				"context": "male"
+			},
+			{
+				"firstName": "Fialka",
+				"context": "female"
+			},
+			{
+				"firstName": "Filip",
+				"context": "male"
+			},
+			{
+				"firstName": "Františka",
+				"context": "female"
+			},
+			{
+				"firstName": "Gouda",
+				"context": "male"
+			},
+			{
+				"firstName": "Grácie",
+				"context": "female"
+			},
+			{
+				"firstName": "Gvendolína",
+				"context": "female"
+			},
+			{
+				"firstName": "Habrovec",
+				"context": "male"
+			},
+			{
+				"firstName": "Háta",
+				"context": "male"
+			},
+			{
+				"firstName": "Hložek",
+				"context": "male"
+			},
+			{
+				"firstName": "Horácio",
+				"context": "male"
+			},
+			{
+				"firstName": "Hyacint",
+				"context": "male"
+			},
+			{
+				"firstName": "Iris",
+				"context": "female"
+			},
+			{
+				"firstName": "Jalovec",
+				"context": "male"
+			},
+			{
+				"firstName": "Janek",
+				"context": "male"
+			},
+			{
+				"firstName": "Jasan",
+				"context": "male"
+			},
+			{
+				"firstName": "Jaspis",
+				"context": "male"
+			},
+			{
+				"firstName": "Jeřabinka",
+				"context": "female"
+			},
+			{
+				"firstName": "Jílovec",
+				"context": "male"
+			},
+			{
+				"firstName": "Jiřička",
+				"context": "female"
+			},
+			{
+				"firstName": "Karmína",
+				"context": "female"
+			},
+			{
+				"firstName": "Klára",
+				"context": "female"
+			},
+			{
+				"firstName": "Kmínek",
+				"context": "male"
+			},
+			{
+				"firstName": "Konrád",
+				"context": "male"
+			},
+			{
+				"firstName": "Kostřava",
+				"context": "female"
+			},
+			{
+				"firstName": "Krokus",
+				"context": "male"
+			},
+			{
+				"firstName": "Kuklík",
+				"context": "male"
+			},
+			{
+				"firstName": "Květa",
+				"context": "female"
+			},
+			{
+				"firstName": "Levandule",
+				"context": "female"
+			},
+			{
+				"firstName": "Lilie",
+				"context": "female"
+			},
+			{
+				"firstName": "Líska",
+				"context": "female"
+			},
+			{
+				"firstName": "Lorenz",
+				"context": "male"
+			},
+			{
+				"firstName": "Magnolie",
+				"context": "female"
+			},
+			{
+				"firstName": "Majoránka",
+				"context": "female"
+			},
+			{
+				"firstName": "Makovec",
+				"context": "male"
+			},
+			{
+				"firstName": "Máslena",
+				"context": "female"
+			},
+			{
+				"firstName": "Meduňka",
+				"context": "female"
+			},
+			{
+				"firstName": "Měsíček",
+				"context": "male"
+			},
+			{
+				"firstName": "Muškát",
+				"context": "male"
+			},
+			{
+				"firstName": "Myrta",
+				"context": "female"
+			},
+			{
+				"firstName": "Niva",
+				"context": "female"
+			},
+			{
+				"firstName": "Nora",
+				"context": "female"
+			},
+			{
+				"firstName": "Okřál",
+				"context": "male"
+			},
+			{
+				"firstName": "Oliver",
+				"context": "male"
+			},
+			{
+				"firstName": "Olivie",
+				"context": "female"
+			},
+			{
+				"firstName": "Olša",
+				"context": "female"
+			},
+			{
+				"firstName": "Opál",
+				"context": "male"
+			},
+			{
+				"firstName": "Otýlie",
+				"context": "female"
+			},
+			{
+				"firstName": "Pelyňka",
+				"context": "female"
+			},
+			{
+				"firstName": "Pepřík",
+				"context": "male"
+			},
+			{
+				"firstName": "Perla",
+				"context": "female"
+			},
+			{
+				"firstName": "Rípčíp",
+				"context": "male"
+			},
+			{
+				"firstName": "Rokfór",
+				"context": "male"
+			},
+			{
+				"firstName": "Routa",
+				"context": "male"
+			},
+			{
+				"firstName": "Rozmarín",
+				"context": "male"
+			},
+			{
+				"firstName": "Rozmarína",
+				"context": "female"
+			},
+			{
+				"firstName": "Rulík",
+				"context": "male"
+			},
+			{
+				"firstName": "Řebřík",
+				"context": "male"
+			},
+			{
+				"firstName": "Sedmikráska",
+				"context": "female"
+			},
+			{
+				"firstName": "Slídie",
+				"context": "female"
+			},
+			{
+				"firstName": "Smaragd",
+				"context": "male"
+			},
+			{
+				"firstName": "Svízel",
+				"context": "male"
+			},
+			{
+				"firstName": "Šafrán",
+				"context": "male"
+			},
+			{
+				"firstName": "Šimon",
+				"context": "male"
+			},
+			{
+				"firstName": "Šípek",
+				"context": "male"
+			},
+			{
+				"firstName": "Šťavel",
+				"context": "male"
+			},
+			{
+				"firstName": "Tis",
+				"context": "male"
+			},
+			{
+				"firstName": "Vavřinec",
+				"context": "male"
+			},
+			{
+				"firstName": "Vilík",
+				"context": "male"
+			},
+			{
+				"firstName": "Višňa",
+				"context": "female"
+			},
+			{
+				"firstName": "Višňa",
+				"context": "male"
+			},
+			{
+				"firstName": "Vlnka",
+				"context": "female"
+			},
+			{
+				"firstName": "Vrbena",
+				"context": "female"
+			},
+			{
+				"firstName": "Vřesena",
+				"context": "female"
+			},
+			{
+				"firstName": "Vřesík",
+				"context": "male"
+			},
+			{
+				"firstName": "Zuzanka",
+				"context": "female"
+			},
+			{
+				"firstName": "Žitmil",
+				"context": "male"
+			}
+		],
+		"familyNames": [
+			{
+				"familyName_firstName=male": "Bílý",
+				"familyName_firstName=female": "Bílá"
+			},
+			{
+				"familyName_firstName=male": "Černý",
+				"familyName_firstName=female": "Černá"
+			},
+			{
+				"familyName_firstName=male": "Čihař",
+				"familyName_firstName=female": "Čihařová"
+			},
+			{
+				"familyName_firstName=male": "Darček",
+				"familyName_firstName=female": "Darčeková"
+			},
+			{
+				"familyName_firstName=male": "Durman",
+				"familyName_firstName=female": "Durmanová"
+			},
+			{
+				"familyName_firstName=male": "Hrabal",
+				"familyName_firstName=female": "Hrabalová"
+			},
+			{
+				"familyName_firstName=male": "Chalva",
+				"familyName_firstName=female": "Chalvová"
+			},
+			{
+				"familyName_firstName=male": "Jařinka",
+				"familyName_firstName=female": "Jařinková"
+			},
+			{
+				"familyName_firstName=male": "Jeleňák",
+				"familyName_firstName=female": "Jeleňáková"
+			},
+			{
+				"familyName_firstName=male": "Jeseň",
+				"familyName_firstName=female": "Jeseňová"
+			},
+			{
+				"familyName_firstName=male": "Katzenreiser",
+				"familyName_firstName=female": "Katzenreiserová"
+			},
+			{
+				"familyName_firstName=male": "Máselník",
+				"familyName_firstName=female": "Máselníková"
+			},
+			{
+				"familyName_firstName=male": "Píp",
+				"familyName_firstName=female": "Pípová"
+			},
+			{
+				"familyName_firstName=male": "Řešetlák",
+				"familyName_firstName=female": "Řešetláková"
+			},
+			{
+				"familyName_firstName=male": "Semínko",
+				"familyName_firstName=female": "Semínková"
+			},
+			{
+				"familyName_firstName=male": "Sníh",
+				"familyName_firstName=female": "Sněhová"
+			},
+			{
+				"familyName_firstName=male": "Strážný",
+				"familyName_firstName=female": "Strážná"
+			},
+			{
+				"familyName_firstName=male": "Trnka",
+				"familyName_firstName=female": "Trnková"
+			},
+			{
+				"familyName_firstName=male": "Urobil",
+				"familyName_firstName=female": "Urobilová"
+			},
+			{
+				"familyName_firstName=male": "Žvanil",
+				"familyName_firstName=female": "Žvanilová"
+			}
+		],
+		"birthSigns": [
+			{
+				"title": "Hvězda",
+				"disposition": {
+					"disposition_firstName=male": "Statečný / zbrklý",
+					"disposition": "Statečná / zbrklá"
+				}
+			},
+			{
+				"title": "Kolo",
+				"disposition": {
+					"disposition_firstName=male": "Pracovitý / nenápadný",
+					"disposition": "Pracovitá / nenápaditá"
+				}
+			},
+			{
+				"title": "Žalud",
+				"disposition": {
+					"disposition_firstName=male": "Zvědavý / paličatý",
+					"disposition": "Zvědavá / paličatá"
+				}
+			},
+			{
+				"title": "Bouřka",
+				"disposition": {
+					"disposition_firstName=male": "Štědrý / popudlivý",
+					"disposition": "Štědrá / popudlivá"
+				}
+			},
+			{
+				"title": "Měsíc",
+				"disposition": {
+					"disposition_firstName=male": "Moudrý / záhadný",
+					"disposition": "Moudrá / záhadná"
+				}
+			},
+			{
+				"title": "Matka",
+				"disposition": {
+					"disposition_firstName=male": "Pečující / ustaraný",
+					"disposition": "Pečující / ustaraná"
+				}
+			}
+		],
+		"coatColors": [
+			"Čokoládová",
+			"Černá",
+			"Bílá",
+			"Světle hnědá",
+			"Šedá",
+			"Namodralá"
+		],
+		"coatPatterns": [
+			"jednolitá",
+			"mourovatá",
+			"strakatá",
+			"pruhovaná",
+			"tečkovaná",
+			"skvrnitá"
+		],
+		"physicalDetail": [
+			"Tělo plné jizev",
+			"Korpulentní tělo",
+			"Vychrtlé tělo",
+			"Klackovité tělo",
+			"Drobné tělíčko",
+			"Rozložité tělo",
+			"Válečné malování",
+			"Cizokrajné oblečení",
+			"Elegantní oblečení",
+			"Záplatované oblečení",
+			"Módní oblečení",
+			"Neprané oblečení",
+			"Useknuté ucho",
+			"Neforemný obličej",
+			"Krásný obličej",
+			"Baculatý obličej",
+			"Jemné rysy v obličeji",
+			"Protáhlý obličej",
+			"Načesaná srst",
+			"Dredy",
+			"Nabarvená srst",
+			"Oholená srst",
+			"Kudrnatá srst",
+			"Sametová srst",
+			"Oči temné jako noc",
+			"Páska přes oko",
+			"Krvavě rudé oči",
+			"Moudrý pohled",
+			"Pronikavý pohled",
+			"Blyštivé oči",
+			"Zastřižený ocásek",
+			"Ocásek jako bič",
+			"Chocholatý ocásek",
+			"Pahýl ocásku",
+			"Chápavý ocásek",
+			"Zakroucený ocásek"
+		]
+	}
 }

--- a/src/locales/cs/mouse_generator.json
+++ b/src/locales/cs/mouse_generator.json
@@ -1,1124 +1,1122 @@
 {
-	"title": "Chrabrý myší dobrodruh...",
-	"pageTitle": "Vytvoř myš",
-	"ui": {
-		"rollButton": "Hoď znovu"
-	},
-	"fields": {
-		"name": "Jméno",
-		"background": "Původ",
-		"birthsign": "Rodné znamení",
-		"disposition": "Povaha",
-		"coat": "Srst",
-		"physicalDetail": "Výrazný rys",
-		"str": "Síla",
-		"dex": "Mrš.",
-		"wil": "Vůle",
-		"hp": "BO",
-		"max": "Maximum",
-		"current": "Aktuální",
-		"inventory": "Inventář",
-		"additionalItems": "Další vybavení",
-		"pips": "Ďobky"
-	},
-	"data": {
-		"standardItems": [
-			{
-				"name": "Zásoby"
-			},
-			{
-				"name": "Pochodeň"
-			},
-			{
-				"name": "Zbraň dle tvého výběru",
-				"notCard": true
-			}
-		],
-		"backgrounds": [
-			{
-				"title": {
-					"background_firstName=male": "Pokusný myšák",
-					"background": "Pokusná myš"
-				},
-				"items": [
-					{
-						"name": "Kouzelná střela",
-						"type": "Kouzlo"
-					},
-					{
-						"name": "Olověný plášť",
-						"type": "Těžká zbroj",
-						"shape": "tall",
-						"def": "1 obr."
-					}
-				]
-			},
-			{
-				"title": "Kuchyňský slídil",
-				"items": [
-					{
-						"name": "Štít a kabátec",
-						"type": "Lehká zbroj",
-						"shape": "wide",
-						"def": "1 obr."
-					},
-					{
-						"name": "Hrnce"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=male": "Uprchlík z klece",
-					"background": "Uprchlice z klece"
-				},
-				"items": [
-					{
-						"name": "Srozumitelnost",
-						"type": "Kouzlo"
-					},
-					{
-						"name": "Láhev mléka"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=male": "Čaroděj",
-					"background": "Čarodějnice"
-				},
-				"items": [
-					{
-						"name": "Zahojení",
-						"type": "Kouzlo"
-					},
-					{
-						"name": "Vonná tyčka"
-					}
-				]
-			},
-			{
-				"title": "Kožešník",
-				"items": [
-					{
-						"name": "Štít a kabátec",
-						"type": "Lehká zbroj",
-						"shape": "wide",
-						"def": "1 obr."
-					},
-					{
-						"name": "Silné nůžky"
-					}
-				]
-			},
-			{
-				"title": "Pouliční rváč",
-				"items": [
-					{
-						"name": "Dýka",
-						"type": "Lehká",
-						"attack": "k6"
-					},
-					{
-						"name": "Láhev kávy"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Žebravá kněžka",
-					"background": "Žebravý kněz"
-				},
-				"items": [
-					{
-						"name": "Zotavení",
-						"type": "Kouzlo"
-					},
-					{
-						"name": "Svatý symbol"
-					}
-				]
-			},
-			{
-				"title": "Honák brouků",
-				"items": [
-					{
-						"name": "Pomocník: Věrný brouk",
-						"notCard": true
-					},
-					{
-						"name": "Tyč, 15 cm"
-					}
-				]
-			},
-			{
-				"title": "Sládek",
-				"items": [
-					{
-						"name": "Pomocník: Opilý světlonoš",
-						"notCard": true
-					},
-					{
-						"name": "Soudek piva"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Rybářka",
-					"background": "Rybář"
-				},
-				"items": [
-					{
-						"name": "Jehla",
-						"type": "Lehká",
-						"attack": "k6"
-					},
-					{
-						"name": "Síť"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Kovářka",
-					"background": "Kovář"
-				},
-				"items": [
-					{
-						"name": "Kladivo",
-						"type": "Střední",
-						"attack": "k6/k8"
-					},
-					{
-						"name": "Pilník na železo"
-					}
-				]
-			},
-			{
-				"title": "Dráteník",
-				"items": [
-					{
-						"name": "Drát, klubko"
-					},
-					{
-						"name": "Elektrická lampa",
-						"usage": 6
-					}
-				]
-			},
-			{
-				"title": "Dřevorubec",
-				"items": [
-					{
-						"name": "Sekera",
-						"type": "Střední",
-						"attack": "k6/k8"
-					},
-					{
-						"name": "Motouz, klubko"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Členka netopýřího kultu",
-					"background": "Člen netopýřího kultu"
-				},
-				"items": [
-					{
-						"name": "Tma",
-						"type": "Kouzlo"
-					},
-					{
-						"name": "Pytlík netopýřích zubů"
-					}
-				]
-			},
-			{
-				"title": "Horník v cínovém dole",
-				"items": [
-					{
-						"name": "Krumpáč",
-						"type": "Střední",
-						"attack": "k6/k8"
-					},
-					{
-						"name": "Lucerna"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Sběračka odpadků",
-					"background": "Sběrač odpadků"
-				},
-				"items": [
-					{
-						"name": "Hák na odpadky",
-						"type": "Těžká",
-						"attack": "k10",
-						"shape": "tall"
-					},
-					{
-						"name": "Zrcátko"
-					}
-				]
-			},
-			{
-				"title": "Stěnolezec",
-				"items": [
-					{
-						"name": "Rybářský háček"
-					},
-					{
-						"name": "Nit, cívka"
-					}
-				]
-			},
-			{
-				"title": "Kupec",
-				"items": [
-					{
-						"name": "Pomocník: Tažná krysa",
-						"notCard": true
-					},
-					{
-						"name": "Směnka od šlechtice na 20 ď"
-					}
-				]
-			},
-			{
-				"title": "Vorař",
-				"items": [
-					{
-						"name": "Kladivo",
-						"type": "Střední",
-						"attack": "k6/k8"
-					},
-					{
-						"name": "Dřevěné klíny"
-					}
-				]
-			},
-			{
-				"title": "Honák žížal",
-				"items": [
-					{
-						"name": "Tyč, 15 cm"
-					},
-					{
-						"name": "Mýdlo"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Vlaštovkářka",
-					"background": "Vlaštovkář"
-				},
-				"items": [
-					{
-						"name": "Rybářský háček"
-					},
-					{
-						"name": "Ochranné brýle"
-					}
-				]
-			},
-			{
-				"title": "Kanálník",
-				"items": [
-					{
-						"name": "Pilník na železo"
-					},
-					{
-						"name": "Nit, cívka"
-					}
-				]
-			},
-			{
-				"title": "Žalářník",
-				"items": [
-					{
-						"name": "Kopí",
-						"type": "Těžká",
-						"attack": "k10",
-						"shape": "tall"
-					},
-					{
-						"name": "Řetěz, 15 cm"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Pěstitelka hub",
-					"background": "Pěstitel hub"
-				},
-				"items": [
-					{
-						"name": "Sušené houby"
-					},
-					{
-						"name": "Maska proti spórám"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Stavitelka hrází",
-					"background": "Stavitel hrází"
-				},
-				"items": [
-					{
-						"name": "Lopata"
-					},
-					{
-						"name": "Dřevěné klíny"
-					}
-				]
-			},
-			{
-				"title": "Kartograf",
-				"items": [
-					{
-						"name": "Brk a inkoust"
-					},
-					{
-						"name": "Kompas"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Vykradačka pastiček",
-					"background": "Vykradač pastiček"
-				},
-				"items": [
-					{
-						"name": "Kus sýra"
-					},
-					{
-						"name": "Lepidlo"
-					}
-				]
-			},
-			{
-				"title": "Tulák",
-				"items": [
-					{
-						"name": "Stan",
-						"shape": "tall"
-					},
-					{
-						"name": "Mapa k pokladu, pochybná"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Pěstitelka obilí",
-					"background": "Pěstitel obilí"
-				},
-				"items": [
-					{
-						"name": "Kopí",
-						"type": "Těžká",
-						"attack": "k10",
-						"shape": "tall"
-					},
-					{
-						"name": "Píšťalka"
-					}
-				]
-			},
-			{
-				"title": "Poslíček",
-				"items": [
-					{
-						"name": "Deka"
-					},
-					{
-						"name": "Dokumenty, zapečetěné"
-					}
-				]
-			},
-			{
-				"title": "Trubadúr",
-				"items": [
-					{
-						"name": "Hudební nástroj"
-					},
-					{
-						"name": "Maskovací sada"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Hazardní hráčka",
-					"background": "Hazardní hráč"
-				},
-				"items": [
-					{
-						"name": "Zatížené kostky"
-					},
-					{
-						"name": "Zrcátko"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Sběračka mízy",
-					"background": "Sběrač mízy"
-				},
-				"items": [
-					{
-						"name": "Vědro"
-					},
-					{
-						"name": "Dřevěné klíny"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Včelařka",
-					"background": "Včelař"
-				},
-				"items": [
-					{
-						"name": "Sklenice medu"
-					},
-					{
-						"name": "Síť"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Knihovnice",
-					"background": "Knihovník"
-				},
-				"items": [
-					{
-						"name": "Útržek ze starodávné knihy"
-					},
-					{
-						"name": "Brk a inkoust"
-					}
-				]
-			},
-			{
-				"title": {
-					"background_firstName=female": "Zchudlá šlechtična",
-					"background": "Zchudlý šlechtic"
-				},
-				"items": [
-					{
-						"name": "Plstěný klobouk"
-					},
-					{
-						"name": "Parfém"
-					}
-				]
-			}
-		],
-		"firstNames": [
-			{
-				"firstName": "Ada",
-				"context": "female"
-			},
-			{
-				"firstName": "Agáta",
-				"context": "female"
-			},
-			{
-				"firstName": "Akácie",
-				"context": "female"
-			},
-			{
-				"firstName": "Aloe",
-				"context": "female"
-			},
-			{
-				"firstName": "Ambrož",
-				"context": "male"
-			},
-			{
-				"firstName": "Anežka",
-				"context": "female"
-			},
-			{
-				"firstName": "Anýz",
-				"context": "male"
-			},
-			{
-				"firstName": "Apríl",
-				"context": "male"
-			},
-			{
-				"firstName": "Astra",
-				"context": "female"
-			},
-			{
-				"firstName": "Augustín",
-				"context": "male"
-			},
-			{
-				"firstName": "Azalka",
-				"context": "female"
-			},
-			{
-				"firstName": "Bazalka",
-				"context": "female"
-			},
-			{
-				"firstName": "Berylie",
-				"context": "female"
-			},
-			{
-				"firstName": "Bobek",
-				"context": "male"
-			},
-			{
-				"firstName": "Bodlák",
-				"context": "male"
-			},
-			{
-				"firstName": "Bříz",
-				"context": "male"
-			},
-			{
-				"firstName": "Bříza",
-				"context": "female"
-			},
-			{
-				"firstName": "Čedar",
-				"context": "male"
-			},
-			{
-				"firstName": "Čekanka",
-				"context": "female"
-			},
-			{
-				"firstName": "Devětsil",
-				"context": "male"
-			},
-			{
-				"firstName": "Edmund",
-				"context": "male"
-			},
-			{
-				"firstName": "Eidam",
-				"context": "male"
-			},
-			{
-				"firstName": "Elza",
-				"context": "female"
-			},
-			{
-				"firstName": "Emil",
-				"context": "male"
-			},
-			{
-				"firstName": "Erina",
-				"context": "female"
-			},
-			{
-				"firstName": "Estragon",
-				"context": "male"
-			},
-			{
-				"firstName": "Fenykl",
-				"context": "male"
-			},
-			{
-				"firstName": "Fialka",
-				"context": "female"
-			},
-			{
-				"firstName": "Filip",
-				"context": "male"
-			},
-			{
-				"firstName": "Františka",
-				"context": "female"
-			},
-			{
-				"firstName": "Gouda",
-				"context": "male"
-			},
-			{
-				"firstName": "Grácie",
-				"context": "female"
-			},
-			{
-				"firstName": "Gvendolína",
-				"context": "female"
-			},
-			{
-				"firstName": "Habrovec",
-				"context": "male"
-			},
-			{
-				"firstName": "Háta",
-				"context": "male"
-			},
-			{
-				"firstName": "Hložek",
-				"context": "male"
-			},
-			{
-				"firstName": "Horácio",
-				"context": "male"
-			},
-			{
-				"firstName": "Hyacint",
-				"context": "male"
-			},
-			{
-				"firstName": "Iris",
-				"context": "female"
-			},
-			{
-				"firstName": "Jalovec",
-				"context": "male"
-			},
-			{
-				"firstName": "Janek",
-				"context": "male"
-			},
-			{
-				"firstName": "Jasan",
-				"context": "male"
-			},
-			{
-				"firstName": "Jaspis",
-				"context": "male"
-			},
-			{
-				"firstName": "Jeřabinka",
-				"context": "female"
-			},
-			{
-				"firstName": "Jílovec",
-				"context": "male"
-			},
-			{
-				"firstName": "Jiřička",
-				"context": "female"
-			},
-			{
-				"firstName": "Karmína",
-				"context": "female"
-			},
-			{
-				"firstName": "Klára",
-				"context": "female"
-			},
-			{
-				"firstName": "Kmínek",
-				"context": "male"
-			},
-			{
-				"firstName": "Konrád",
-				"context": "male"
-			},
-			{
-				"firstName": "Kostřava",
-				"context": "female"
-			},
-			{
-				"firstName": "Krokus",
-				"context": "male"
-			},
-			{
-				"firstName": "Kuklík",
-				"context": "male"
-			},
-			{
-				"firstName": "Květa",
-				"context": "female"
-			},
-			{
-				"firstName": "Levandule",
-				"context": "female"
-			},
-			{
-				"firstName": "Lilie",
-				"context": "female"
-			},
-			{
-				"firstName": "Líska",
-				"context": "female"
-			},
-			{
-				"firstName": "Lorenz",
-				"context": "male"
-			},
-			{
-				"firstName": "Magnolie",
-				"context": "female"
-			},
-			{
-				"firstName": "Majoránka",
-				"context": "female"
-			},
-			{
-				"firstName": "Makovec",
-				"context": "male"
-			},
-			{
-				"firstName": "Máslena",
-				"context": "female"
-			},
-			{
-				"firstName": "Meduňka",
-				"context": "female"
-			},
-			{
-				"firstName": "Měsíček",
-				"context": "male"
-			},
-			{
-				"firstName": "Muškát",
-				"context": "male"
-			},
-			{
-				"firstName": "Myrta",
-				"context": "female"
-			},
-			{
-				"firstName": "Niva",
-				"context": "female"
-			},
-			{
-				"firstName": "Nora",
-				"context": "female"
-			},
-			{
-				"firstName": "Okřál",
-				"context": "male"
-			},
-			{
-				"firstName": "Oliver",
-				"context": "male"
-			},
-			{
-				"firstName": "Olivie",
-				"context": "female"
-			},
-			{
-				"firstName": "Olša",
-				"context": "female"
-			},
-			{
-				"firstName": "Opál",
-				"context": "male"
-			},
-			{
-				"firstName": "Otýlie",
-				"context": "female"
-			},
-			{
-				"firstName": "Pelyňka",
-				"context": "female"
-			},
-			{
-				"firstName": "Pepřík",
-				"context": "male"
-			},
-			{
-				"firstName": "Perla",
-				"context": "female"
-			},
-			{
-				"firstName": "Rípčíp",
-				"context": "male"
-			},
-			{
-				"firstName": "Rokfór",
-				"context": "male"
-			},
-			{
-				"firstName": "Routa",
-				"context": "male"
-			},
-			{
-				"firstName": "Rozmarín",
-				"context": "male"
-			},
-			{
-				"firstName": "Rozmarína",
-				"context": "female"
-			},
-			{
-				"firstName": "Rulík",
-				"context": "male"
-			},
-			{
-				"firstName": "Řebřík",
-				"context": "male"
-			},
-			{
-				"firstName": "Sedmikráska",
-				"context": "female"
-			},
-			{
-				"firstName": "Slídie",
-				"context": "female"
-			},
-			{
-				"firstName": "Smaragd",
-				"context": "male"
-			},
-			{
-				"firstName": "Svízel",
-				"context": "male"
-			},
-			{
-				"firstName": "Šafrán",
-				"context": "male"
-			},
-			{
-				"firstName": "Šimon",
-				"context": "male"
-			},
-			{
-				"firstName": "Šípek",
-				"context": "male"
-			},
-			{
-				"firstName": "Šťavel",
-				"context": "male"
-			},
-			{
-				"firstName": "Tis",
-				"context": "male"
-			},
-			{
-				"firstName": "Vavřinec",
-				"context": "male"
-			},
-			{
-				"firstName": "Vilík",
-				"context": "male"
-			},
-			{
-				"firstName": "Višňa",
-				"context": "female"
-			},
-			{
-				"firstName": "Višňa",
-				"context": "male"
-			},
-			{
-				"firstName": "Vlnka",
-				"context": "female"
-			},
-			{
-				"firstName": "Vrbena",
-				"context": "female"
-			},
-			{
-				"firstName": "Vřesena",
-				"context": "female"
-			},
-			{
-				"firstName": "Vřesík",
-				"context": "male"
-			},
-			{
-				"firstName": "Zuzanka",
-				"context": "female"
-			},
-			{
-				"firstName": "Žitmil",
-				"context": "male"
-			}
-		],
-		"familyNames": [
-			{
-				"familyName_firstName=male": "Bílý",
-				"familyName_firstName=female": "Bílá"
-			},
-			{
-				"familyName_firstName=male": "Černý",
-				"familyName_firstName=female": "Černá"
-			},
-			{
-				"familyName_firstName=male": "Čihař",
-				"familyName_firstName=female": "Čihařová"
-			},
-			{
-				"familyName_firstName=male": "Darček",
-				"familyName_firstName=female": "Darčeková"
-			},
-			{
-				"familyName_firstName=male": "Durman",
-				"familyName_firstName=female": "Durmanová"
-			},
-			{
-				"familyName_firstName=male": "Hrabal",
-				"familyName_firstName=female": "Hrabalová"
-			},
-			{
-				"familyName_firstName=male": "Chalva",
-				"familyName_firstName=female": "Chalvová"
-			},
-			{
-				"familyName_firstName=male": "Jařinka",
-				"familyName_firstName=female": "Jařinková"
-			},
-			{
-				"familyName_firstName=male": "Jeleňák",
-				"familyName_firstName=female": "Jeleňáková"
-			},
-			{
-				"familyName_firstName=male": "Jeseň",
-				"familyName_firstName=female": "Jeseňová"
-			},
-			{
-				"familyName_firstName=male": "Katzenreiser",
-				"familyName_firstName=female": "Katzenreiserová"
-			},
-			{
-				"familyName_firstName=male": "Máselník",
-				"familyName_firstName=female": "Máselníková"
-			},
-			{
-				"familyName_firstName=male": "Píp",
-				"familyName_firstName=female": "Pípová"
-			},
-			{
-				"familyName_firstName=male": "Řešetlák",
-				"familyName_firstName=female": "Řešetláková"
-			},
-			{
-				"familyName_firstName=male": "Semínko",
-				"familyName_firstName=female": "Semínková"
-			},
-			{
-				"familyName_firstName=male": "Sníh",
-				"familyName_firstName=female": "Sněhová"
-			},
-			{
-				"familyName_firstName=male": "Strážný",
-				"familyName_firstName=female": "Strážná"
-			},
-			{
-				"familyName_firstName=male": "Trnka",
-				"familyName_firstName=female": "Trnková"
-			},
-			{
-				"familyName_firstName=male": "Urobil",
-				"familyName_firstName=female": "Urobilová"
-			},
-			{
-				"familyName_firstName=male": "Žvanil",
-				"familyName_firstName=female": "Žvanilová"
-			}
-		],
-		"birthSigns": [
-			{
-				"title": "Hvězda",
-				"disposition": {
-					"disposition_firstName=male": "Statečný / zbrklý",
-					"disposition": "Statečná / zbrklá"
-				}
-			},
-			{
-				"title": "Kolo",
-				"disposition": {
-					"disposition_firstName=male": "Pracovitý / nenápadný",
-					"disposition": "Pracovitá / nenápaditá"
-				}
-			},
-			{
-				"title": "Žalud",
-				"disposition": {
-					"disposition_firstName=male": "Zvědavý / paličatý",
-					"disposition": "Zvědavá / paličatá"
-				}
-			},
-			{
-				"title": "Bouřka",
-				"disposition": {
-					"disposition_firstName=male": "Štědrý / popudlivý",
-					"disposition": "Štědrá / popudlivá"
-				}
-			},
-			{
-				"title": "Měsíc",
-				"disposition": {
-					"disposition_firstName=male": "Moudrý / záhadný",
-					"disposition": "Moudrá / záhadná"
-				}
-			},
-			{
-				"title": "Matka",
-				"disposition": {
-					"disposition_firstName=male": "Pečující / ustaraný",
-					"disposition": "Pečující / ustaraná"
-				}
-			}
-		],
-		"coatColors": [
-			"Čokoládová",
-			"Černá",
-			"Bílá",
-			"Světle hnědá",
-			"Šedá",
-			"Namodralá"
-		],
-		"coatPatterns": [
-			"jednolitá",
-			"mourovatá",
-			"strakatá",
-			"pruhovaná",
-			"tečkovaná",
-			"skvrnitá"
-		],
-		"physicalDetail": [
-			"Tělo plné jizev",
-			"Korpulentní tělo",
-			"Vychrtlé tělo",
-			"Klackovité tělo",
-			"Drobné tělíčko",
-			"Rozložité tělo",
-			"Válečné malování",
-			"Cizokrajné oblečení",
-			"Elegantní oblečení",
-			"Záplatované oblečení",
-			"Módní oblečení",
-			"Neprané oblečení",
-			"Useknuté ucho",
-			"Neforemný obličej",
-			"Krásný obličej",
-			"Baculatý obličej",
-			"Jemné rysy v obličeji",
-			"Protáhlý obličej",
-			"Načesaná srst",
-			"Dredy",
-			"Nabarvená srst",
-			"Oholená srst",
-			"Kudrnatá srst",
-			"Sametová srst",
-			"Oči temné jako noc",
-			"Páska přes oko",
-			"Krvavě rudé oči",
-			"Moudrý pohled",
-			"Pronikavý pohled",
-			"Blyštivé oči",
-			"Zastřižený ocásek",
-			"Ocásek jako bič",
-			"Chocholatý ocásek",
-			"Pahýl ocásku",
-			"Chápavý ocásek",
-			"Zakroucený ocásek"
-		]
-	}
+    "background": "Původ",
+    "birthsign": "Rodné znamení",
+    "title": "Chrabrý myší dobrodruh...",
+    "pageTitle": "Vytvoř myš",
+    "ui": {
+        "rollButton": "Hoď znovu"
+    },
+    "fields": {
+        "name": "Jméno",
+        "background": "Původ",
+        "birthsign": "Rodné znamení",
+        "disposition": "Povaha",
+        "coat": "Srst",
+        "physicalDetail": "Výrazný rys",
+        "str": "Síla",
+        "dex": "Mrš.",
+        "wil": "Vůle",
+        "hp": "BO",
+        "max": "Maximum",
+        "current": "Aktuální",
+        "inventory": "Inventář",
+        "additionalItems": "Další vybavení",
+        "pips": "Ďobky"
+    },
+    "data": {
+        "standardItems": [
+            {
+                "name": "Zásoby"
+            },
+            {
+                "name": "Pochodeň"
+            },
+            {
+                "name": "Zbraň dle tvého výběru",
+                "notCard": true
+            }
+        ],
+        "backgrounds": [
+            {
+                "title": {
+                    "background_firstName=male": "Pokusný myšák",
+                    "background": "Pokusná myš"
+                },
+                "items": [
+                    {
+                        "name": "Kouzelná střela",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Olověný plášť",
+                        "type": "Těžká zbroj",
+                        "shape": "tall",
+                        "def": "1 obr."
+                    }
+                ]
+            },
+            {
+                "title": "Kuchyňský slídil",
+                "items": [
+                    {
+                        "name": "Štít a kabátec",
+                        "type": "Lehká zbroj",
+                        "shape": "wide",
+                        "def": "1 obr."
+                    },
+                    {
+                        "name": "Hrnce"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=male": "Uprchlík z klece",
+                    "background": "Uprchlice z klece"
+                },
+                "items": [
+                    {
+                        "name": "Srozumitelnost",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Láhev mléka"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=male": "Čaroděj",
+                    "background": "Čarodějnice"
+                },
+                "items": [
+                    {
+                        "name": "Zahojení",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Vonná tyčka"
+                    }
+                ]
+            },
+            {
+                "title": "Kožešník",
+                "items": [
+                    {
+                        "name": "Štít a kabátec",
+                        "type": "Lehká zbroj",
+                        "shape": "wide",
+                        "def": "1 obr."
+                    },
+                    {
+                        "name": "Silné nůžky"
+                    }
+                ]
+            },
+            {
+                "title": "Pouliční rváč",
+                "items": [
+                    {
+                        "name": "Dýka",
+                        "type": "Lehká",
+                        "attack": "k6"
+                    },
+                    {
+                        "name": "Láhev kávy"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Žebravá kněžka",
+                    "background": "Žebravý kněz"
+                },
+                "items": [
+                    {
+                        "name": "Zotavení",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Svatý symbol"
+                    }
+                ]
+            },
+            {
+                "title": "Honák brouků",
+                "items": [
+                    {
+                        "name": "Pomocník: Věrný brouk",
+                        "notCard": true
+                    },
+                    {
+                        "name": "Tyč, 15 cm"
+                    }
+                ]
+            },
+            {
+                "title": "Sládek",
+                "items": [
+                    {
+                        "name": "Pomocník: Opilý světlonoš",
+                        "notCard": true
+                    },
+                    {
+                        "name": "Soudek piva"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Rybářka",
+                    "background": "Rybář"
+                },
+                "items": [
+                    {
+                        "name": "Jehla",
+                        "type": "Lehká",
+                        "attack": "k6"
+                    },
+                    {
+                        "name": "Síť"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Kovářka",
+                    "background": "Kovář"
+                },
+                "items": [
+                    {
+                        "name": "Kladivo",
+                        "type": "Střední",
+                        "attack": "k6/k8"
+                    },
+                    {
+                        "name": "Pilník na železo"
+                    }
+                ]
+            },
+            {
+                "title": "Dráteník",
+                "items": [
+                    {
+                        "name": "Drát, klubko"
+                    },
+                    {
+                        "name": "Elektrická lampa",
+                        "usage": 6
+                    }
+                ]
+            },
+            {
+                "title": "Dřevorubec",
+                "items": [
+                    {
+                        "name": "Sekera",
+                        "type": "Střední",
+                        "attack": "k6/k8"
+                    },
+                    {
+                        "name": "Motouz, klubko"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Členka netopýřího kultu",
+                    "background": "Člen netopýřího kultu"
+                },
+                "items": [
+                    {
+                        "name": "Tma",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Pytlík netopýřích zubů"
+                    }
+                ]
+            },
+            {
+                "title": "Horník v cínovém dole",
+                "items": [
+                    {
+                        "name": "Krumpáč",
+                        "type": "Střední",
+                        "attack": "k6/k8"
+                    },
+                    {
+                        "name": "Lucerna"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Sběračka odpadků",
+                    "background": "Sběrač odpadků"
+                },
+                "items": [
+                    {
+                        "name": "Hák na odpadky",
+                        "type": "Těžká",
+                        "attack": "k10",
+                        "shape": "tall"
+                    },
+                    {
+                        "name": "Zrcátko"
+                    }
+                ]
+            },
+            {
+                "title": "Stěnolezec",
+                "items": [
+                    {
+                        "name": "Rybářský háček"
+                    },
+                    {
+                        "name": "Nit, cívka"
+                    }
+                ]
+            },
+            {
+                "title": "Kupec",
+                "items": [
+                    {
+                        "name": "Pomocník: Tažná krysa",
+                        "notCard": true
+                    },
+                    {
+                        "name": "Směnka od šlechtice na 20 ď"
+                    }
+                ]
+            },
+            {
+                "title": "Vorař",
+                "items": [
+                    {
+                        "name": "Kladivo",
+                        "type": "Střední",
+                        "attack": "k6/k8"
+                    },
+                    {
+                        "name": "Dřevěné klíny"
+                    }
+                ]
+            },
+            {
+                "title": "Honák žížal",
+                "items": [
+                    {
+                        "name": "Tyč, 15 cm"
+                    },
+                    {
+                        "name": "Mýdlo"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Vlaštovkářka",
+                    "background": "Vlaštovkář"
+                },
+                "items": [
+                    {
+                        "name": "Rybářský háček"
+                    },
+                    {
+                        "name": "Ochranné brýle"
+                    }
+                ]
+            },
+            {
+                "title": "Kanálník",
+                "items": [
+                    {
+                        "name": "Pilník na železo"
+                    },
+                    {
+                        "name": "Nit, cívka"
+                    }
+                ]
+            },
+            {
+                "title": "Žalářník",
+                "items": [
+                    {
+                        "name": "Kopí",
+                        "type": "Těžká",
+                        "attack": "k10",
+                        "shape": "tall"
+                    },
+                    {
+                        "name": "Řetěz, 15 cm"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Pěstitelka hub",
+                    "background": "Pěstitel hub"
+                },
+                "items": [
+                    {
+                        "name": "Sušené houby"
+                    },
+                    {
+                        "name": "Maska proti spórám"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Stavitelka hrází",
+                    "background": "Stavitel hrází"
+                },
+                "items": [
+                    {
+                        "name": "Lopata"
+                    },
+                    {
+                        "name": "Dřevěné klíny"
+                    }
+                ]
+            },
+            {
+                "title": "Kartograf",
+                "items": [
+                    {
+                        "name": "Brk a inkoust"
+                    },
+                    {
+                        "name": "Kompas"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Vykradačka pastiček",
+                    "background": "Vykradač pastiček"
+                },
+                "items": [
+                    {
+                        "name": "Kus sýra"
+                    },
+                    {
+                        "name": "Lepidlo"
+                    }
+                ]
+            },
+            {
+                "title": "Tulák",
+                "items": [
+                    {
+                        "name": "Stan",
+                        "shape": "tall"
+                    },
+                    {
+                        "name": "Mapa k pokladu, pochybná"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Pěstitelka obilí",
+                    "background": "Pěstitel obilí"
+                },
+                "items": [
+                    {
+                        "name": "Kopí",
+                        "type": "Těžká",
+                        "attack": "k10",
+                        "shape": "tall"
+                    },
+                    {
+                        "name": "Píšťalka"
+                    }
+                ]
+            },
+            {
+                "title": "Poslíček",
+                "items": [
+                    {
+                        "name": "Deka"
+                    },
+                    {
+                        "name": "Dokumenty, zapečetěné"
+                    }
+                ]
+            },
+            {
+                "title": "Trubadúr",
+                "items": [
+                    {
+                        "name": "Hudební nástroj"
+                    },
+                    {
+                        "name": "Maskovací sada"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Hazardní hráčka",
+                    "background": "Hazardní hráč"
+                },
+                "items": [
+                    {
+                        "name": "Zatížené kostky"
+                    },
+                    {
+                        "name": "Zrcátko"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Sběračka mízy",
+                    "background": "Sběrač mízy"
+                },
+                "items": [
+                    {
+                        "name": "Vědro"
+                    },
+                    {
+                        "name": "Dřevěné klíny"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Včelařka",
+                    "background": "Včelař"
+                },
+                "items": [
+                    {
+                        "name": "Sklenice medu"
+                    },
+                    {
+                        "name": "Síť"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Knihovnice",
+                    "background": "Knihovník"
+                },
+                "items": [
+                    {
+                        "name": "Útržek ze starodávné knihy"
+                    },
+                    {
+                        "name": "Brk a inkoust"
+                    }
+                ]
+            },
+            {
+                "title": {
+                    "background_firstName=female": "Zchudlá šlechtična",
+                    "background": "Zchudlý šlechtic"
+                },
+                "items": [
+                    {
+                        "name": "Plstěný klobouk"
+                    },
+                    {
+                        "name": "Parfém"
+                    }
+                ]
+            }
+        ],
+        "firstNames": [
+            {
+                "firstName": "Ada",
+                "context": "female"
+            },
+            {
+                "firstName": "Agáta",
+                "context": "female"
+            },
+            {
+                "firstName": "Akácie",
+                "context": "female"
+            },
+            {
+                "firstName": "Aloe",
+                "context": "female"
+            },
+            {
+                "firstName": "Ambrož",
+                "context": "male"
+            },
+            {
+                "firstName": "Anežka",
+                "context": "female"
+            },
+            {
+                "firstName": "Anýz",
+                "context": "male"
+            },
+            {
+                "firstName": "Apríl",
+                "context": "male"
+            },
+            {
+                "firstName": "Astra",
+                "context": "female"
+            },
+            {
+                "firstName": "Augustín",
+                "context": "male"
+            },
+            {
+                "firstName": "Azalka",
+                "context": "female"
+            },
+            {
+                "firstName": "Bazalka",
+                "context": "female"
+            },
+            {
+                "firstName": "Berylie",
+                "context": "female"
+            },
+            {
+                "firstName": "Bobek",
+                "context": "male"
+            },
+            {
+                "firstName": "Bodlák",
+                "context": "male"
+            },
+            {
+                "firstName": "Bříz",
+                "context": "male"
+            },
+            {
+                "firstName": "Čedar",
+                "context": "male"
+            },
+            {
+                "firstName": "Čekanka",
+                "context": "female"
+            },
+            {
+                "firstName": "Devětsil",
+                "context": "male"
+            },
+            {
+                "firstName": "Edmund",
+                "context": "male"
+            },
+            {
+                "firstName": "Eidam",
+                "context": "male"
+            },
+            {
+                "firstName": "Elza",
+                "context": "female"
+            },
+            {
+                "firstName": "Emil",
+                "context": "male"
+            },
+            {
+                "firstName": "Erina",
+                "context": "female"
+            },
+            {
+                "firstName": "Estragon",
+                "context": "male"
+            },
+            {
+                "firstName": "Fenykl",
+                "context": "male"
+            },
+            {
+                "firstName": "Fialka",
+                "context": "female"
+            },
+            {
+                "firstName": "Filip",
+                "context": "male"
+            },
+            {
+                "firstName": "Františka",
+                "context": "female"
+            },
+            {
+                "firstName": "Gouda",
+                "context": "male"
+            },
+            {
+                "firstName": "Gouda",
+                "context": "female"
+            },
+            {
+                "firstName": "Grácie",
+                "context": "female"
+            },
+            {
+                "firstName": "Gvendolína",
+                "context": "female"
+            },
+            {
+                "firstName": "Habrovec",
+                "context": "male"
+            },
+            {
+                "firstName": "Háta",
+                "context": "male"
+            },
+            {
+                "firstName": "Hložek",
+                "context": "male"
+            },
+            {
+                "firstName": "Horácio",
+                "context": "male"
+            },
+            {
+                "firstName": "Hyacint",
+                "context": "male"
+            },
+            {
+                "firstName": "Iris",
+                "context": "female"
+            },
+            {
+                "firstName": "Jalovec",
+                "context": "male"
+            },
+            {
+                "firstName": "Janek",
+                "context": "male"
+            },
+            {
+                "firstName": "Jasan",
+                "context": "male"
+            },
+            {
+                "firstName": "Jaspis",
+                "context": "male"
+            },
+            {
+                "firstName": "Jeřabinka",
+                "context": "female"
+            },
+            {
+                "firstName": "Jílovec",
+                "context": "male"
+            },
+            {
+                "firstName": "Jiřička",
+                "context": "female"
+            },
+            {
+                "firstName": "Karmína",
+                "context": "female"
+            },
+            {
+                "firstName": "Klára",
+                "context": "female"
+            },
+            {
+                "firstName": "Kmínek",
+                "context": "male"
+            },
+            {
+                "firstName": "Konrád",
+                "context": "male"
+            },
+            {
+                "firstName": "Kostřava",
+                "context": "female"
+            },
+            {
+                "firstName": "Krokus",
+                "context": "male"
+            },
+            {
+                "firstName": "Kuklík",
+                "context": "male"
+            },
+            {
+                "firstName": "Květa",
+                "context": "female"
+            },
+            {
+                "firstName": "Levandule",
+                "context": "female"
+            },
+            {
+                "firstName": "Lilie",
+                "context": "female"
+            },
+            {
+                "firstName": "Líska",
+                "context": "female"
+            },
+            {
+                "firstName": "Lorenz",
+                "context": "male"
+            },
+            {
+                "firstName": "Magnolie",
+                "context": "female"
+            },
+            {
+                "firstName": "Majoránka",
+                "context": "female"
+            },
+            {
+                "firstName": "Makovec",
+                "context": "male"
+            },
+            {
+                "firstName": "Máslena",
+                "context": "female"
+            },
+            {
+                "firstName": "Meduňka",
+                "context": "female"
+            },
+            {
+                "firstName": "Měsíček",
+                "context": "male"
+            },
+            {
+                "firstName": "Muškát",
+                "context": "male"
+            },
+            {
+                "firstName": "Myrta",
+                "context": "female"
+            },
+            {
+                "firstName": "Niva",
+                "context": "female"
+            },
+            {
+                "firstName": "Nora",
+                "context": "female"
+            },
+            {
+                "firstName": "Okřál",
+                "context": "male"
+            },
+            {
+                "firstName": "Oliver",
+                "context": "male"
+            },
+            {
+                "firstName": "Olivie",
+                "context": "female"
+            },
+            {
+                "firstName": "Olša",
+                "context": "male"
+            },
+            {
+                "firstName": "Opál",
+                "context": "male"
+            },
+            {
+                "firstName": "Otýlie",
+                "context": "female"
+            },
+            {
+                "firstName": "Pelyňka",
+                "context": "female"
+            },
+            {
+                "firstName": "Pepřík",
+                "context": "male"
+            },
+            {
+                "firstName": "Perla",
+                "context": "female"
+            },
+            {
+                "firstName": "Rípčíp",
+                "context": "male"
+            },
+            {
+                "firstName": "Rokfór",
+                "context": "male"
+            },
+            {
+                "firstName": "Routa",
+                "context": "male"
+            },
+            {
+                "firstName": "Rozmarín",
+                "context": "male"
+            },
+            {
+                "firstName": "Rulík",
+                "context": "male"
+            },
+            {
+                "firstName": "Řebřík",
+                "context": "male"
+            },
+            {
+                "firstName": "Sedmikráska",
+                "context": "female"
+            },
+            {
+                "firstName": "Slídie",
+                "context": "female"
+            },
+            {
+                "firstName": "Smaragd",
+                "context": "male"
+            },
+            {
+                "firstName": "Svízel",
+                "context": "male"
+            },
+            {
+                "firstName": "Šafrán",
+                "context": "male"
+            },
+            {
+                "firstName": "Šimon",
+                "context": "male"
+            },
+            {
+                "firstName": "Šípek",
+                "context": "male"
+            },
+            {
+                "firstName": "Šťavel",
+                "context": "male"
+            },
+            {
+                "firstName": "Tis",
+                "context": "male"
+            },
+            {
+                "firstName": "Vavřinec",
+                "context": "male"
+            },
+            {
+                "firstName": "Vilík",
+                "context": "male"
+            },
+            {
+                "firstName": "Višňa",
+                "context": "female"
+            },
+            {
+                "firstName": "Višňa",
+                "context": "male"
+            },
+            {
+                "firstName": "Vlnka",
+                "context": "female"
+            },
+            {
+                "firstName": "Vrbena",
+                "context": "female"
+            },
+            {
+                "firstName": "Vřesena",
+                "context": "female"
+            },
+            {
+                "firstName": "Vřesík",
+                "context": "male"
+            },
+            {
+                "firstName": "Zuzanka",
+                "context": "female"
+            },
+            {
+                "firstName": "Žitmil",
+                "context": "male"
+            }
+        ],
+        "familyNames": [
+            {
+                "familyName_firstName=male": "Bílý",
+                "familyName_firstName=female": "Bílá"
+            },
+            {
+                "familyName_firstName=male": "Černý",
+                "familyName_firstName=female": "Černá"
+            },
+            {
+                "familyName_firstName=male": "Čihař",
+                "familyName_firstName=female": "Čihařová"
+            },
+            {
+                "familyName_firstName=male": "Darček",
+                "familyName_firstName=female": "Darčeková"
+            },
+            {
+                "familyName_firstName=male": "Durman",
+                "familyName_firstName=female": "Durmanová"
+            },
+            {
+                "familyName_firstName=male": "Hrabal",
+                "familyName_firstName=female": "Hrabalová"
+            },
+            {
+                "familyName_firstName=male": "Chalva",
+                "familyName_firstName=female": "Chalvová"
+            },
+            {
+                "familyName_firstName=male": "Jařinka",
+                "familyName_firstName=female": "Jařinková"
+            },
+            {
+                "familyName_firstName=male": "Jeleňák",
+                "familyName_firstName=female": "Jeleňáková"
+            },
+            {
+                "familyName_firstName=male": "Jeseň",
+                "familyName_firstName=female": "Jeseňová"
+            },
+            {
+                "familyName_firstName=male": "Katzenreiser",
+                "familyName_firstName=female": "Katzenreiserová"
+            },
+            {
+                "familyName_firstName=male": "Máselník",
+                "familyName_firstName=female": "Máselníková"
+            },
+            {
+                "familyName_firstName=male": "Píp",
+                "familyName_firstName=female": "Pípová"
+            },
+            {
+                "familyName_firstName=male": "Řešetlák",
+                "familyName_firstName=female": "Řešetláková"
+            },
+            {
+                "familyName_firstName=male": "Semínko",
+                "familyName_firstName=female": "Semínková"
+            },
+            {
+                "familyName_firstName=male": "Sníh",
+                "familyName_firstName=female": "Sněhová"
+            },
+            {
+                "familyName_firstName=male": "Strážný",
+                "familyName_firstName=female": "Strážná"
+            },
+            {
+                "familyName_firstName=male": "Trnka",
+                "familyName_firstName=female": "Trnková"
+            },
+            {
+                "familyName_firstName=male": "Urobil",
+                "familyName_firstName=female": "Urobilová"
+            },
+            {
+                "familyName_firstName=male": "Žvanil",
+                "familyName_firstName=female": "Žvanilová"
+            }
+        ],
+        "birthSigns": [
+            {
+                "title": "Hvězda",
+                "disposition": {
+                    "disposition_firstName=male": "Statečný / zbrklý",
+                    "disposition": "Statečná / zbrklá"
+                }
+            },
+            {
+                "title": "Kolo",
+                "disposition": {
+                    "disposition_firstName=male": "Pracovitý / nenápaditý",
+                    "disposition": "Pracovitá / nenápaditá"
+                }
+            },
+            {
+                "title": "Žalud",
+                "disposition": {
+                    "disposition_firstName=male": "Zvědavý / paličatý",
+                    "disposition": "Zvědavá / paličatá"
+                }
+            },
+            {
+                "title": "Bouřka",
+                "disposition": {
+                    "disposition_firstName=male": "Štědrý / popudlivý",
+                    "disposition": "Štědrá / popudlivá"
+                }
+            },
+            {
+                "title": "Měsíc",
+                "disposition": {
+                    "disposition_firstName=male": "Moudrý / záhadný",
+                    "disposition": "Moudrá / záhadná"
+                }
+            },
+            {
+                "title": "Matka",
+                "disposition": {
+                    "disposition_firstName=male": "Pečující / ustaraný",
+                    "disposition": "Pečující / ustaraná"
+                }
+            }
+        ],
+        "coatColors": [
+            "Čokoládová",
+            "Černá",
+            "Bílá",
+            "Světle hnědá",
+            "Šedá",
+            "Namodralá"
+        ],
+        "coatPatterns": [
+            "jednolitá",
+            "mourovatá",
+            "strakatá",
+            "pruhovaná",
+            "tečkovaná",
+            "skvrnitá"
+        ],
+        "physicalDetail": [
+            "Tělo plné jizev",
+            "Korpulentní tělo",
+            "Vychrtlé tělo",
+            "Klackovité tělo",
+            "Drobné tělíčko",
+            "Rozložité tělo",
+            "Válečné malování",
+            "Cizokrajné oblečení",
+            "Elegantní oblečení",
+            "Záplatované oblečení",
+            "Módní oblečení",
+            "Neprané oblečení",
+            "Useknuté ucho",
+            "Neforemný obličej",
+            "Krásný obličej",
+            "Baculatý obličej",
+            "Jemné rysy v obličeji",
+            "Protáhlý obličej",
+            "Načesaná srst",
+            "Dredy",
+            "Nabarvená srst",
+            "Oholená srst",
+            "Kudrnatá srst",
+            "Sametová srst",
+            "Oči temné jako noc",
+            "Páska přes oko",
+            "Krvavě rudé oči",
+            "Moudrý pohled",
+            "Pronikavý pohled",
+            "Blyštivé oči",
+            "Zastřižený ocásek",
+            "Ocásek jako bič",
+            "Chocholatý ocásek",
+            "Pahýl ocásku",
+            "Chápavý ocásek",
+            "Zakroucený ocásek"
+        ]
+    }
 }

--- a/src/locales/cs/mouse_generator.json
+++ b/src/locales/cs/mouse_generator.json
@@ -1,0 +1,680 @@
+{
+    "title": "Chrabrý myší dobrodruh...",
+    "pageTitle": "Vytvoř myš",
+    "ui": {
+        "rollButton": "Hoď znovu"
+    },
+    "fields": {
+        "name": "Jméno",
+        "background": "Původ",
+        "birthsign": "Rodné znamení",
+        "disposition": "Povaha",
+        "coat": "Srst",
+        "physicalDetail": "Výrazný rys",
+        "str": "Síla",
+        "dex": "Mrš.",
+        "wil": "Vůle",
+        "hp": "BO",
+        "max": "Maximum",
+        "current": "Aktuální",
+        "inventory": "Inventář",
+        "additionalItems": "Další vybavení",
+        "pips": "Ďobky"
+    },
+    "data": {
+        "standardItems": [
+            {
+                "name": "Zásoby"
+            },
+            {
+                "name": "Pochodeň"
+            },
+            {
+                "name": "Zbraň dle tvého výběru",
+                "notCard": true
+            }
+        ],
+        "backgrounds": [
+            {
+                "title": "Test subject",
+                "items": [
+                    {
+                        "name": "Kouzelná střela",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Olověný plášť",
+                        "type": "Těžká zbroj",
+                        "shape": "tall",
+                        "def": "1 obr."
+                    }
+                ]
+            },
+            {
+                "title": "Kuchyňský slídil",
+                "items": [
+                    {
+                        "name": "Štít a kabátec",
+                        "type": "Lehká zbroj",
+                        "shape": "wide",
+                        "def": "1 obr."
+                    },
+                    {
+                        "name": "Hrnce"
+                    }
+                ]
+            },
+            {
+                "title": "Uprchlík z klece",
+                "items": [
+                    {
+                        "name": "Srozumitelnost",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Láhev mléka"
+                    }
+                ]
+            },
+            {
+                "title": "Čarodějnice",
+                "items": [
+                    {
+                        "name": "Zahojení",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Vonná tyčka"
+                    }
+                ]
+            },
+            {
+                "title": "Kožešník",
+                "items": [
+                    {
+                        "name": "Štít a kabátec",
+                        "type": "Lehká zbroj",
+                        "shape": "wide",
+                        "def": "1 obr."
+                    },
+                    {
+                        "name": "Silné nůžky"
+                    }
+                ]
+            },
+            {
+                "title": "Pouliční rváč",
+                "items": [
+                    {
+                        "name": "Dýka",
+                        "type": "Lehká",
+                        "attack": "k6"
+                    },
+                    {
+                        "name": "Láhev kávy"
+                    }
+                ]
+            },
+            {
+                "title": "Žebravý kněz",
+                "items": [
+                    {
+                        "name": "Zotavení",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Svatý symbol"
+                    }
+                ]
+            },
+            {
+                "title": "Honák brouků",
+                "items": [
+                    {
+                        "name": "Pomocník: Věrný brouk",
+                        "notCard": true
+                    },
+                    {
+                        "name": "Tyč, 15 cm"
+                    }
+                ]
+            },
+            {
+                "title": "Sládek",
+                "items": [
+                    {
+                        "name": "Pomocník: Opilý světlonoš",
+                        "notCard": true
+                    },
+                    {
+                        "name": "Soudek piva"
+                    }
+                ]
+            },
+            {
+                "title": "Rybář",
+                "items": [
+                    {
+                        "name": "Jehla",
+                        "type": "Lehká",
+                        "attack": "k6"
+                    },
+                    {
+                        "name": "Síť"
+                    }
+                ]
+            },
+            {
+                "title": "Kovář",
+                "items": [
+                    {
+                        "name": "Kladivo",
+                        "type": "Střední",
+                        "attack": "k6/k8"
+                    },
+                    {
+                        "name": "Pilník na železo"
+                    }
+                ]
+            },
+            {
+                "title": "Dráteník",
+                "items": [
+                    {
+                        "name": "Drát, klubko"
+                    },
+                    {
+                        "name": "Elektrická lampa",
+                        "usage": 6
+                    }
+                ]
+            },
+            {
+                "title": "Dřevorubec",
+                "items": [
+                    {
+                        "name": "Sekera",
+                        "type": "Střední",
+                        "attack": "k6/k8"
+                    },
+                    {
+                        "name": "Motouz, klubko"
+                    }
+                ]
+            },
+            {
+                "title": "Člen netopýřího kultu",
+                "items": [
+                    {
+                        "name": "Tma",
+                        "type": "Kouzlo"
+                    },
+                    {
+                        "name": "Pytlík netopýřích zubů"
+                    }
+                ]
+            },
+            {
+                "title": "Horník v cínovém dole",
+                "items": [
+                    {
+                        "name": "Krumpáč",
+                        "type": "Střední",
+                        "attack": "k6/k8"
+                    },
+                    {
+                        "name": "Lucerna"
+                    }
+                ]
+            },
+            {
+                "title": "Sběrač odpadků",
+                "items": [
+                    {
+                        "name": "Hák na odpadky",
+                        "type": "Těžká",
+                        "attack": "k10",
+                        "shape": "tall"
+                    },
+                    {
+                        "name": "Zrcátko"
+                    }
+                ]
+            },
+            {
+                "title": "Stěnolezec",
+                "items": [
+                    {
+                        "name": "Rybářský háček"
+                    },
+                    {
+                        "name": "Nit, cívka"
+                    }
+                ]
+            },
+            {
+                "title": "Kupec",
+                "items": [
+                    {
+                        "name": "Pomocník: Tažná krysa",
+                        "notCard": true
+                    },
+                    {
+                        "name": "Směnka od šlechtice na 20 ď"
+                    }
+                ]
+            },
+            {
+                "title": "Vorař",
+                "items": [
+                    {
+                        "name": "Kladivo",
+                        "type": "Střední",
+                        "attack": "k6/k8"
+                    },
+                    {
+                        "name": "Dřevěné klíny"
+                    }
+                ]
+            },
+            {
+                "title": "Honák žížal",
+                "items": [
+                    {
+                        "name": "Tyč, 15 cm"
+                    },
+                    {
+                        "name": "Mýdlo"
+                    }
+                ]
+            },
+            {
+                "title": "Vlaštovkář",
+                "items": [
+                    {
+                        "name": "Rybářský háček"
+                    },
+                    {
+                        "name": "Ochranné brýle"
+                    }
+                ]
+            },
+            {
+                "title": "Kanálník",
+                "items": [
+                    {
+                        "name": "Pilník na železo"
+                    },
+                    {
+                        "name": "Nit, cívka"
+                    }
+                ]
+            },
+            {
+                "title": "Žalářník",
+                "items": [
+                    {
+                        "name": "Kopí",
+                        "type": "Těžká",
+                        "attack": "k10",
+                        "shape": "tall"
+                    },
+                    {
+                        "name": "Řetěz, 15 cm"
+                    }
+                ]
+            },
+            {
+                "title": "Pěstitel hub",
+                "items": [
+                    {
+                        "name": "Sušené houby"
+                    },
+                    {
+                        "name": "Maska proti spórám"
+                    }
+                ]
+            },
+            {
+                "title": "Stavitel hrází",
+                "items": [
+                    {
+                        "name": "Lopata"
+                    },
+                    {
+                        "name": "Dřevěné klíny"
+                    }
+                ]
+            },
+            {
+                "title": "Kartograf",
+                "items": [
+                    {
+                        "name": "Brk a inkoust"
+                    },
+                    {
+                        "name": "Kompas"
+                    }
+                ]
+            },
+            {
+                "title": "Vykradač pastiček",
+                "items": [
+                    {
+                        "name": "Kus sýra"
+                    },
+                    {
+                        "name": "Lepidlo"
+                    }
+                ]
+            },
+            {
+                "title": "Tulák",
+                "items": [
+                    {
+                        "name": "Stan",
+                        "shape": "tall"
+                    },
+                    {
+                        "name": "Mapa k pokladu, pochybná"
+                    }
+                ]
+            },
+            {
+                "title": "Pěstitel obilí",
+                "items": [
+                    {
+                        "name": "Kopí",
+                        "type": "Těžká",
+                        "attack": "k10",
+                        "shape": "tall"
+                    },
+                    {
+                        "name": "Píšťalka"
+                    }
+                ]
+            },
+            {
+                "title": "Poslíček",
+                "items": [
+                    {
+                        "name": "Deka"
+                    },
+                    {
+                        "name": "Dokumenty, zapečetěné"
+                    }
+                ]
+            },
+            {
+                "title": "Trubadúr",
+                "items": [
+                    {
+                        "name": "Hudební nástroj"
+                    },
+                    {
+                        "name": "Maskovací sada"
+                    }
+                ]
+            },
+            {
+                "title": "Hazardní hráč",
+                "items": [
+                    {
+                        "name": "Zatížené kostky"
+                    },
+                    {
+                        "name": "Zrcátko"
+                    }
+                ]
+            },
+            {
+                "title": "Sběrač mízy",
+                "items": [
+                    {
+                        "name": "Vědro"
+                    },
+                    {
+                        "name": "Dřevěné klíny"
+                    }
+                ]
+            },
+            {
+                "title": "Včelař",
+                "items": [
+                    {
+                        "name": "Sklenice medu"
+                    },
+                    {
+                        "name": "Síť"
+                    }
+                ]
+            },
+            {
+                "title": "Knihovník",
+                "items": [
+                    {
+                        "name": "Útržek ze starodávné knihy"
+                    },
+                    {
+                        "name": "Brk a inkoust"
+                    }
+                ]
+            },
+            {
+                "title": "Zchudlý šlechtic",
+                "items": [
+                    {
+                        "name": "Plstěný klobouk"
+                    },
+                    {
+                        "name": "Parfém"
+                    }
+                ]
+            }
+        ],
+        "firstNames": [
+            "Ada",
+            "Agáta",
+            "Akácie",
+            "Aloe",
+            "Ambrož",
+            "Anežka",
+            "Anýz",
+            "Apríl",
+            "Astra",
+            "Augustín",
+            "Azalka",
+            "Bazalka",
+            "Berylie",
+            "Bobek",
+            "Bodlák",
+            "Bříz",
+            "Čedar",
+            "Čekanka",
+            "Devětsil",
+            "Edmund",
+            "Eidam",
+            "Elza",
+            "Emil",
+            "Erina",
+            "Estragon",
+            "Fenykl",
+            "Fialka",
+            "Filip",
+            "Františka",
+            "Gouda",
+            "Grácie",
+            "Gvendolína",
+            "Habrovec",
+            "Háta",
+            "Hložek",
+            "Horácio",
+            "Hyacint",
+            "Iris",
+            "Jalovec",
+            "Janek",
+            "Jasan",
+            "Jaspis",
+            "Jeřabinka",
+            "Jílovec",
+            "Jiřička",
+            "Karmína",
+            "Klára",
+            "Kmínek",
+            "Konrád",
+            "Kostřava",
+            "Krokus",
+            "Kuklík",
+            "Květa",
+            "Levandule",
+            "Lilie",
+            "Líska",
+            "Lorenz",
+            "Magnolie",
+            "Majoránka",
+            "Makovec",
+            "Máslena",
+            "Meduňka",
+            "Měsíček",
+            "Muškát",
+            "Myrta",
+            "Niva",
+            "Nora",
+            "Okřál",
+            "Oliver",
+            "Olivie",
+            "Olša",
+            "Opál",
+            "Otýlie",
+            "Pelyňka",
+            "Pepřík",
+            "Perla",
+            "Rípčíp",
+            "Rokfór",
+            "Routa",
+            "Rozmarín",
+            "Rulík",
+            "Řebřík",
+            "Sedmikráska",
+            "Slídie",
+            "Smaragd",
+            "Svízel",
+            "Šafrán",
+            "Šimon",
+            "Šípek",
+            "Šťavel",
+            "Tis",
+            "Vavřinec",
+            "Vilík",
+            "Višňa",
+            "Vlnka",
+            "Vrbena",
+            "Vřesena",
+            "Vřesík",
+            "Zuzanka",
+            "Žitmil"
+        ],
+        "familyNames": [
+            "Bílý/Bílá",
+            "Černý/Černá",
+            "Čihař/Čihařová",
+            "Darček/Darčeková",
+            "Durman/Durmanová",
+            "Hrabal/Hrabalová",
+            "Chalva/Chalvová",
+            "Jařinka/Jařinková",
+            "Jeleňák/Jeleňáková",
+            "Jeseň/Jeseňová",
+            "Katzenreiser/Katzenreiserová",
+            "Máselník/Máselníková",
+            "Píp/Pípová",
+            "Řešetlák/Řešetláková",
+            "Semínko/Semínková",
+            "Sníh/Sněhová",
+            "Strážný/Strážná",
+            "Trnka/Trnková",
+            "Urobil/Urobilová",
+            "Žvanil/Žvanilová"
+        ],
+        "birthSigns": [
+            {
+                "title": "Hvězda",
+                "disposition": "Statečná / zbrklá"
+            },
+            {
+                "title": "Kolo",
+                "disposition": "Pracovitá / nenápaditá"
+            },
+            {
+                "title": "Žalud",
+                "disposition": "Zvědavá / paličatá"
+            },
+            {
+                "title": "Bouřka",
+                "disposition": "Štědrá / popudlivá"
+            },
+            {
+                "title": "Měsíc",
+                "disposition": "Moudrá / záhadná"
+            },
+            {
+                "title": "Matka",
+                "disposition": "Pečující / ustaraná"
+            }
+        ],
+        "coatColors": [
+            "Čokoládová",
+            "Černá",
+            "Bílá",
+            "Světle hnědá",
+            "Šedá",
+            "Namodralá"
+        ],
+        "coatPatterns": [
+            "jednolitá",
+            "mourovatá",
+            "strakatá",
+            "pruhovaná",
+            "tečkovaná",
+            "skvrnitá"
+        ],
+        "physicalDetail": [
+            "Tělo plné jizev",
+            "Korpulentní tělo",
+            "Vychrtlé tělo",
+            "Klackovité tělo",
+            "Drobné tělíčko",
+            "Rozložité tělo",
+            "Válečné malování",
+            "Cizokrajné oblečení",
+            "Elegantní oblečení",
+            "Záplatované oblečení",
+            "Módní oblečení",
+            "Neprané oblečení",
+            "Useknuté ucho",
+            "Neforemný obličej",
+            "Krásný obličej",
+            "Baculatý obličej",
+            "Jemné rysy v obličeji",
+            "Protáhlý obličej",
+            "Načesaná srst",
+            "Dredy",
+            "Nabarvená srst",
+            "Oholená srst",
+            "Kudrnatá srst",
+            "Sametová srst",
+            "Oči temné jako noc",
+            "Páska přes oko",
+            "Krvavě rudé oči",
+            "Moudrý pohled",
+            "Pronikavý pohled",
+            "Blyštivé oči",
+            "Zastřižený ocásek",
+            "Ocásek jako bič",
+            "Chocholatý ocásek",
+            "Pahýl ocásku",
+            "Chápavý ocásek",
+            "Zakroucený ocásek"
+        ]
+    }
+}

--- a/src/locales/en/adventure_site_generator.json
+++ b/src/locales/en/adventure_site_generator.json
@@ -13,7 +13,7 @@
     },
     "data": {
         "siteName": {
-            "partA": [
+            "modifier": [
                 "Black",
                 "White",
                 "Green",
@@ -35,7 +35,7 @@
                 "Dry",
                 "Sodden"
             ],
-            "partB": [
+            "location": [
                 "Stump",
                 "Tree",
                 "Oak",

--- a/src/locales/it/adventure_site_generator.json
+++ b/src/locales/it/adventure_site_generator.json
@@ -13,7 +13,7 @@
     },
     "data": {
         "siteName": {
-            "partA": [
+            "modifier": [
                 "Ceppo",
                 "Albero",
                 "Quercia",
@@ -50,7 +50,7 @@
                 "Nido",
                 "Antro"
             ],
-            "partB": [
+            "location": [
                 "d’Ebano",
                 "d’Avorio",
                 "Verde",


### PR DESCRIPTION
I have started working on translating website generators into Czech language.

This translation is based on excellent work done by our local publisher [Mytago](https://www.mytago.cz/mausritter), which I have used as a starting point.
They have translated both [item card studio](https://www.mytago.cz/item-card-studio/) and [mouse generator](https://www.mytago.cz/vytvor-mys) into Czech language and host them on their website.

Currently, the tools hosted on their website are quite outdated with some technical problems and inconsistent translation.
I would like to bring their work to the official website so everyone can benefit from generator improvements and changes.

I have made this pull request as a preview, since there are few problems that need to be sorted out first.

1. Text with special Czech characters
   - Special characters like _š, ř, é, ý, á, ň_ are not displayed correctly when text is using FF Brokenscript font
   - There might be a font loading problem, since some of these characters are displayed correctly on Mytago website

2. Adventure site generator translation
   - Currently it's impossible to translate adventure site generator into Czech language
   - The problem is with site name creation and summary sentence composition
   - For example: site name is created by combining two word parts - in Czech, the first part might change based on gender of second part
   - A temporally solution might be just to "disable" Czech language option in adventure site generator language picker

